### PR TITLE
Initialize Chrome Extension Service in background script

### DIFF
--- a/commands/commands.js
+++ b/commands/commands.js
@@ -1,10 +1,15 @@
 /*
  * This file is the main entry point for all ribbon button commands.
  * It imports functions from other modules and associates them with Office actions.
+ *
+ * This file also serves as a background script that runs continuously,
+ * even when taskpanes are closed, making it ideal for services that need
+ * to always be listening (like the Chrome Extension Service).
  */
 import { openImportDialog } from './import.js';
 import { openCreateLdaDialog } from './lda.js';
 import { toggleHighlight, transferData } from './actions.js';
+import chromeExtensionService from '../react/src/services/chromeExtensionService.js';
 
 // This function is required for the Analytics button, even if it does nothing,
 // because the manifest uses a ShowTaskpane action.
@@ -18,3 +23,29 @@ Office.actions.associate("openImportDialog", openImportDialog);
 Office.actions.associate("transferData", transferData);
 Office.actions.associate("openCreateLdaDialog", openCreateLdaDialog);
 Office.actions.associate("openAnalyticsPane", openAnalyticsPane);
+
+// Initialize background services when Office is ready
+Office.onReady(() => {
+  console.log("Background script initialized - starting Chrome Extension Service");
+
+  // Start extension detection
+  // This will continuously ping to detect the Chrome extension
+  chromeExtensionService.startPinging();
+
+  // Start keep-alive heartbeat to prevent extension from going dormant
+  chromeExtensionService.startKeepAlive();
+
+  // Add a listener for extension events
+  chromeExtensionService.addListener((event) => {
+    console.log("Background: Chrome Extension event:", event);
+
+    // Handle different event types
+    if (event.type === "installed") {
+      console.log("Background: Chrome extension detected and ready!");
+    } else if (event.type === "message") {
+      console.log("Background: Received message from extension:", event.data);
+    }
+  });
+
+  console.log("Chrome Extension Service is now running in the background");
+});


### PR DESCRIPTION
The chromeExtensionService now runs in the background via the FunctionFile (commands.js), which stays loaded even when taskpanes are closed. This enables continuous listening for Chrome extension messages throughout the add-in lifecycle.

Changes:
- Import chromeExtensionService in commands.js
- Initialize service on Office.onReady()
- Start extension detection pinging
- Start keep-alive heartbeat
- Add event listener for extension communication