### PR TITLE
Add autoload functionality to start background services on document open

### DIFF
--- a/commands/commands.js
+++ b/commands/commands.js
@@ -17,12 +17,22 @@ function openAnalyticsPane(event) {
     event.completed();
 }
 
+// Called automatically when a new document is opened
+// This ensures the background service starts on document load
+function onDocumentOpen(event) {
+    console.log("Document opened - background services are active");
+    event.completed();
+}
+
 // Register ribbon button commands
 Office.actions.associate("toggleHighlight", toggleHighlight);
 Office.actions.associate("openImportDialog", openImportDialog);
 Office.actions.associate("transferData", transferData);
 Office.actions.associate("openCreateLdaDialog", openCreateLdaDialog);
 Office.actions.associate("openAnalyticsPane", openAnalyticsPane);
+
+// Register autoload event handler
+Office.actions.associate("onDocumentOpen", onDocumentOpen);
 
 // Initialize background services when Office is ready
 Office.onReady(() => {

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
   <Id>a8b1e479-1b3d-4e9e-9a1c-2f8e1c8b4a0e</Id>
-  <Version>2.0.3.2</Version>
+  <Version>2.1.0.0</Version>
   <ProviderName>Victor Blanco</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Student Retention Add-in"/>
@@ -21,6 +21,14 @@
     <RequestedWidth>450</RequestedWidth>
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
+
+  <!-- Requirements for autoload functionality -->
+  <Requirements>
+    <Sets DefaultMinVersion="1.1">
+      <Set Name="SharedRuntime" MinVersion="1.1"/>
+    </Sets>
+  </Requirements>
+
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
       <Host xsi:type="Workbook">
@@ -30,8 +38,21 @@
             <Description resid="GetStarted.Description"/>
             <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
           </GetStarted>
-          
+
           <FunctionFile resid="Commands.Url"/>
+
+          <!-- Runtimes for shared runtime and autoload -->
+          <Runtimes>
+            <Runtime resid="Commands.Url" lifetime="long" />
+          </Runtimes>
+
+          <!-- LaunchEvent: Load add-in automatically when document opens -->
+          <ExtensionPoint xsi:type="LaunchEvent">
+            <LaunchEvents>
+              <LaunchEvent Type="OnNewDocument" FunctionName="onDocumentOpen" />
+            </LaunchEvents>
+            <SourceLocation resid="Commands.Url" />
+          </ExtensionPoint>
 
           <ExtensionPoint xsi:type="PrimaryCommandSurface">
             <CustomTab id="Victor.RetentionTab">


### PR DESCRIPTION
Configure the add-in to load automatically when Excel opens, eliminating the need to click a ribbon button first. The background Chrome Extension Service now starts immediately when any Excel document is opened.

Changes to manifest.xml:
- Add Requirements section for SharedRuntime 1.1+
- Add Runtimes configuration with long lifetime
- Add LaunchEvent extension point for OnNewDocument
- Bump version to 2.1.0.0

Changes to commands.js:
- Add onDocumentOpen function for LaunchEvent handler
- Register onDocumentOpen with Office.actions

The background service now:
1. Loads when Excel document opens (not on ribbon click)
2. Stays active throughout the Excel session
3. Works even when taskpanes are closed