### PR TITLE
Add OnDocumentOpened event for existing documents

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
   <Id>a8b1e479-1b3d-4e9e-9a1c-2f8e1c8b4a0e</Id>
-  <Version>2.1.0.0</Version>
+  <Version>2.1.0.1</Version>
   <ProviderName>Victor Blanco</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Student Retention Add-in"/>
@@ -50,6 +50,7 @@
           <ExtensionPoint xsi:type="LaunchEvent">
             <LaunchEvents>
               <LaunchEvent Type="OnNewDocument" FunctionName="onDocumentOpen" />
+              <LaunchEvent Type="OnDocumentOpened" FunctionName="onDocumentOpen" />
             </LaunchEvents>
             <SourceLocation resid="Commands.Url" />
           </ExtensionPoint>


### PR DESCRIPTION
Add OnDocumentOpened LaunchEvent to trigger autoload when opening existing documents, not just new ones. This ensures the background service starts whether the user creates a new document or opens an existing one.

Bump version to 2.1.0.1