### PR TITLE
Refine multi-student selection display

### DIFF
--- a/react/src/components/studentView/Parts/Header.jsx
+++ b/react/src/components/studentView/Parts/Header.jsx
@@ -227,7 +227,7 @@ function StudentHeader({ student, selectedRowCount = 1 }) {
             {selectedRowCount}
           </div>
           <h2 className="text-lg font-bold text-gray-800">
-            {selectedRowCount} Students Selected
+            Students Selected
           </h2>
         </div>
       </div>

--- a/react/src/components/studentView/StudentView.jsx
+++ b/react/src/components/studentView/StudentView.jsx
@@ -268,14 +268,18 @@ function StudentView({ onReady, user }) {
   return (
         <div className="studentview-outer">
             <StudentHeader student={activeStudentState} selectedRowCount={selectedRowCount} />
-            <div className="studentview-tabs">
-                <button type="button" className={`studentview-tab ${activeTab === 'details' ? 'active' : ''}`} onClick={() => setActiveTab('details')}>Details</button>
-                {availableTabs.history && ( <button type="button" className={`studentview-tab ${activeTab === 'history' ? 'active' : ''}`} onClick={() => { loadHistory(); setActiveTab('history'); }}>History</button> )}
-                {availableTabs.assignments && ( <button type="button" className={`studentview-tab ${activeTab === 'assignments' ? 'active' : ''}`} onClick={() => { loadAssignments(); setActiveTab('assignments'); }}>Assignments</button> )}
-            </div>
-            <div className="studentview-tab-content">
-                {renderActiveTab()}
-            </div>
+            {selectedRowCount === 1 && (
+                <>
+                    <div className="studentview-tabs">
+                        <button type="button" className={`studentview-tab ${activeTab === 'details' ? 'active' : ''}`} onClick={() => setActiveTab('details')}>Details</button>
+                        {availableTabs.history && ( <button type="button" className={`studentview-tab ${activeTab === 'history' ? 'active' : ''}`} onClick={() => { loadHistory(); setActiveTab('history'); }}>History</button> )}
+                        {availableTabs.assignments && ( <button type="button" className={`studentview-tab ${activeTab === 'assignments' ? 'active' : ''}`} onClick={() => { loadAssignments(); setActiveTab('assignments'); }}>Assignments</button> )}
+                    </div>
+                    <div className="studentview-tab-content">
+                        {renderActiveTab()}
+                    </div>
+                </>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
- Remove count from text, now shows just "Students Selected" (count remains in badge)
- Hide tabs and content when multiple students are selected
- Only display header for cleaner multi-selection view