### PR TITLE
Fix open all gradebooks to open multiple links

### DIFF
--- a/react/src/components/studentView/MultiStudentView.jsx
+++ b/react/src/components/studentView/MultiStudentView.jsx
@@ -93,14 +93,10 @@ function MultiStudentView({ students }) {
       return;
     }
 
-    gradebookLinks.forEach((link, index) => {
-      setTimeout(() => {
-        if (window.Office && window.Office.context && window.Office.context.ui && window.Office.context.ui.openBrowserWindow) {
-          window.Office.context.ui.openBrowserWindow(link);
-        } else {
-          window.open(link, '_blank');
-        }
-      }, index * 100); // Stagger the opens slightly to avoid popup blockers
+    // For multiple links, always use window.open as Office API only supports single window
+    // Open all immediately - browsers allow multiple windows opened by user action
+    gradebookLinks.forEach((link) => {
+      window.open(link, '_blank', 'noopener,noreferrer');
     });
   };
 


### PR DESCRIPTION
Fixed the issue where clicking "Open All Gradebooks" only opened one link.

Changes:
- Removed setTimeout stagger approach which was unnecessary
- Removed conditional Office.context.ui.openBrowserWindow call (only supports single window)
- Switched to always use window.open() for all gradebook links
- Open all links immediately in the same user action context (prevents popup blocking)
- Added 'noopener,noreferrer' for security best practices

The browser allows multiple windows to open when triggered by a single user action, so all gradebook links now open successfully without delays or API limitations.