### PR TITLE
Fix highlighting error with missing rowIndex property

### DIFF
--- a/react/src/services/chromeExtensionService.js
+++ b/react/src/services/chromeExtensionService.js
@@ -141,7 +141,7 @@ class ChromeExtensionService {
 
         // Load the used range to search for student
         const usedRange = worksheet.getUsedRange();
-        usedRange.load(["values", "rowCount", "columnCount"]);
+        usedRange.load(["values", "rowCount", "columnCount", "rowIndex"]);
         await context.sync();
 
         const values = usedRange.values;


### PR DESCRIPTION
The handleHighlightStudentRow function was accessing usedRange.rowIndex without first loading it via the Excel API. This caused a RichApi.Error: "The property 'rowIndex' is not available. Before reading the property's value, call the load method on the containing object and call 'context.sync()' on the associated request context."

Added "rowIndex" to the usedRange.load() call to ensure the property is loaded before being accessed on line 233.