### PR TITLE
Set up loading screen pings for all views

### DIFF
--- a/react/src/App.jsx
+++ b/react/src/App.jsx
@@ -148,13 +148,13 @@ function App() {
     // B. If user exists, show the requested page
     switch (page) {
       case 'settings':
-        return <Settings user={currentUser} accessToken={accessToken} />; // <-- ADDED: Pass accessToken
+        return <Settings user={currentUser} accessToken={accessToken} onReady={handleFeatureReady} />;
       case 'import':
-        return <ImportManager user={currentUser} />;
+        return <ImportManager user={currentUser} onReady={handleFeatureReady} />;
       case 'about':
-        return <About />;
+        return <About onReady={handleFeatureReady} />;
       case 'create-lda':
-        return <LDAManager user={currentUser} />;
+        return <LDAManager user={currentUser} onReady={handleFeatureReady} />;
       case 'student-view':
       default:
         // Pass user and ready-handler to StudentView

--- a/react/src/components/about/About.jsx
+++ b/react/src/components/about/About.jsx
@@ -1,8 +1,8 @@
 // Timestamp: 2025-11-22 | Version: 3.0.0
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import MarkdownViewer from "../utility/MarkdownViewer";
 
-const About = () => {
+const About = ({ onReady } = {}) => {
   const BASE_URL = import.meta.env.BASE_URL;
   const HOME_FILE = "about.md";
 
@@ -19,6 +19,13 @@ const About = () => {
   };
 
   const goHome = () => setCurrentFileName(HOME_FILE);
+
+  // Signal that About is ready
+  useEffect(() => {
+    if (onReady) {
+      onReady();
+    }
+  }, [onReady]);
 
   return (
     <div className="p-4">

--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -21,7 +21,7 @@ const PROCESS_STEPS = [
   { id: 'finalize', label: 'Finalizing Report' },
 ];
 
-export default function CreateLDAManager() {
+export default function CreateLDAManager({ onReady } = {}) {
   // State for the settings
   const [ldaSettings, setLdaSettings] = useState({
     daysOut: 5,
@@ -72,6 +72,13 @@ export default function CreateLDAManager() {
       }
     };
   }, []);
+
+  // Signal that LDAManager is ready
+  useEffect(() => {
+    if (onReady) {
+      onReady();
+    }
+  }, [onReady]);
 
   const handleSettingChange = (key, value) => {
     setLdaSettings((prev) => ({ ...prev, [key]: value }));

--- a/react/src/components/importData/ImportManager.jsx
+++ b/react/src/components/importData/ImportManager.jsx
@@ -371,7 +371,7 @@ const detectFileInfo = (file, callback) => {
 
 // --- Main Component ---
 
-export default function ImportManager({ onImport, excludeFilter, hyperLink } = {}) {
+export default function ImportManager({ onImport, excludeFilter, hyperLink, onReady } = {}) {
     const [fileName, setFileName] = useState('');
     const [status, setStatus] = useState('');
     const [parsedData, setParsedData] = useState(null);
@@ -723,6 +723,12 @@ export default function ImportManager({ onImport, excludeFilter, hyperLink } = {
         setStatus(`Processing import ${processingIndex + 1} of ${uploadedFiles.length}...`);
     }, [isImported, processingIndex, activeIndex, headers, filteredData, importInfo, matchedWithLink, calculated, renamed, uploadedFiles, lastEmittedIndex, onImport]);
 
+    // Signal that ImportManager is ready
+    useEffect(() => {
+        if (onReady) {
+            onReady();
+        }
+    }, [onReady]);
 
     // --- Render ---
 

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -7,7 +7,7 @@ import WorkbookSettingsModal from './WorkbookSettingsModal'; // <-- ADDED
 import LicenseChecker from '../utility/LicenseChecker'; // <-- License checker (requires Graph API)
 import UserInfoDisplay from '../utility/UserInfoDisplay'; // <-- User info from token (no API needed)
 
-const Settings = ({ user, accessToken }) => { // <-- ADDED accessToken prop
+const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken and onReady props
 	const [activeTab, setActiveTab] = useState('workbook');
 
 	// initialize user settings state from defaults
@@ -148,6 +148,13 @@ const Settings = ({ user, accessToken }) => { // <-- ADDED accessToken prop
 		saveWorkbookSettingsToDocument(initial);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []); // run once on mount
+
+	// Signal that Settings is ready
+	useEffect(() => {
+		if (onReady) {
+			onReady();
+		}
+	}, [onReady]);
 
 	// helper to update a workbook setting (also persist to document)
 	const updateWorkbookSetting = (id, value) => {


### PR DESCRIPTION
- Extended onReady prop from App.jsx to Settings, ImportManager, LDAManager, and About components
- Each component now signals when it's ready to display, preventing premature UI flash
- Loading screen now works consistently across all navigation pages (student-view, settings, import, create-lda, about)
- Matches the existing pattern used in StudentView for a unified loading experience