### PR TITLE
feat: Add conditional formatting to Grade column on import

### DIFF
--- a/documentation/CHROME_EXTENSION_INTEGRATION.md
+++ b/documentation/CHROME_EXTENSION_INTEGRATION.md
@@ -88,6 +88,7 @@ The Chrome extension can send master list data to import into the add-in's Maste
   - Automatically wrap Gradebook URLs in HYPERLINK formulas with "Grade Book" as the display text
   - Preserve existing Gradebook hyperlinks for students already in the list
   - Preserve "Assigned" column values and their colors
+  - Apply 3-color conditional formatting to Grade column (Red → Yellow → Green)
   - Highlight new students in light blue (#ADD8E6)
   - Clear and repopulate the sheet with the imported data
 
@@ -403,6 +404,8 @@ importMasterListToExcel(studentsToImport);
 - The add-in will only import if a "Master List" sheet already exists
 - Column headers are matched case-insensitively with whitespace normalization (e.g., "StudentName" matches "Student Name")
 - Gradebook URLs (starting with http:// or https://) are automatically wrapped in HYPERLINK formulas with "Grade Book" as the display text
+- Grade column receives automatic 3-color conditional formatting (Red for low, Yellow for medium ~70%, Green for high)
+- The formatting automatically detects 0-1 or 0-100 grade scales
 - Existing Gradebook links and Assigned values are preserved for existing students
 - New students will be highlighted in light blue
 - All data must be in array format matching the headers order


### PR DESCRIPTION
Added automatic 3-color scale conditional formatting (Red-Yellow-Green) to the Grade column when importing master list data from Chrome extension.

Features:
- Red color for low grades
- Yellow color for medium grades (70% or 0.7 midpoint)
- Green color for high grades
- Automatically detects if grades are on 0-1 or 0-100 scale
- Clears existing conditional formats to avoid duplicates
- Non-critical operation that won't fail the import if it errors

Updated documentation to reflect this new automatic formatting behavior.