### PR TITLE
Add Azure Function for Office SSO to Graph API token exchange

### DIFF
--- a/azure-function/.funcignore
+++ b/azure-function/.funcignore
@@ -1,0 +1,8 @@
+*.js.map
+*.ts
+.git*
+.vscode
+local.settings.json
+test
+.DS_Store
+node_modules

--- a/azure-function/README.md
+++ b/azure-function/README.md
@@ -1,0 +1,66 @@
+# Token Exchange Azure Function
+
+This Azure Function exchanges Office SSO tokens for Microsoft Graph API tokens using the OAuth2 On-Behalf-Of (OBO) flow.
+
+## Deployment Instructions
+
+### Option 1: Deploy via Azure Portal (Easiest)
+
+1. Go to your Function App in Azure Portal
+2. Click "Deployment Center" in the left menu
+3. Choose deployment method:
+   - **GitHub**: Connect your repository for automatic deployments
+   - **Local Git**: Push directly from your machine
+   - **ZIP Deploy**: Upload the `azure-function` folder as a zip
+
+### Option 2: Deploy via VS Code
+
+1. Install "Azure Functions" extension in VS Code
+2. Sign in to Azure
+3. Right-click the `azure-function` folder
+4. Select "Deploy to Function App..."
+5. Choose your Function App
+
+### Option 3: Deploy via Azure CLI
+
+```bash
+cd azure-function
+az login
+az functionapp deployment source config-zip \
+  --resource-group student-retention-rg \
+  --name your-function-app-name \
+  --src azure-function.zip
+```
+
+## Environment Variables
+
+After deployment, configure these environment variables in Azure Portal:
+
+1. Go to Function App → Configuration → Application settings
+2. Add these variables:
+   - `AZURE_TENANT_ID`: Your Azure AD tenant ID
+   - `AZURE_CLIENT_ID`: Your app registration client ID
+   - `AZURE_CLIENT_SECRET`: Your app client secret
+
+## Testing
+
+Endpoint: `https://your-function-app.azurewebsites.net/api/exchange-token`
+
+Request:
+```json
+POST /api/exchange-token
+Content-Type: application/json
+
+{
+  "token": "your-office-sso-token"
+}
+```
+
+Response:
+```json
+{
+  "accessToken": "graph-api-token",
+  "expiresIn": 3600,
+  "tokenType": "Bearer"
+}
+```

--- a/azure-function/exchangeToken/function.json
+++ b/azure-function/exchangeToken/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post", "options"],
+      "route": "exchange-token"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/azure-function/exchangeToken/index.js
+++ b/azure-function/exchangeToken/index.js
@@ -1,0 +1,127 @@
+/**
+ * Azure Function: Exchange Office SSO Token for Microsoft Graph API Token
+ * Uses OAuth2 On-Behalf-Of (OBO) flow
+ */
+
+module.exports = async function (context, req) {
+    // Handle CORS preflight
+    if (req.method === 'OPTIONS') {
+        context.res = {
+            status: 204,
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'POST, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+                'Access-Control-Max-Age': '86400'
+            }
+        };
+        return;
+    }
+
+    context.log('Token exchange request received');
+
+    try {
+        // Get Office SSO token from request body
+        const { token: officeSsoToken } = req.body;
+
+        if (!officeSsoToken) {
+            context.res = {
+                status: 400,
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Content-Type': 'application/json'
+                },
+                body: { error: 'Missing token in request body' }
+            };
+            return;
+        }
+
+        // Get Azure AD configuration from environment variables
+        const tenantId = process.env.AZURE_TENANT_ID;
+        const clientId = process.env.AZURE_CLIENT_ID;
+        const clientSecret = process.env.AZURE_CLIENT_SECRET;
+
+        if (!tenantId || !clientId || !clientSecret) {
+            context.log.error('Missing Azure AD configuration');
+            context.res = {
+                status: 500,
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Content-Type': 'application/json'
+                },
+                body: { error: 'Server configuration error' }
+            };
+            return;
+        }
+
+        // Exchange token using OAuth2 On-Behalf-Of flow
+        const tokenEndpoint = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+
+        const params = new URLSearchParams({
+            grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            client_id: clientId,
+            client_secret: clientSecret,
+            assertion: officeSsoToken,
+            scope: 'https://graph.microsoft.com/Mail.Send',
+            requested_token_use: 'on_behalf_of'
+        });
+
+        context.log('Exchanging token with Azure AD...');
+
+        const response = await fetch(tokenEndpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: params.toString()
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+            context.log.error('Token exchange failed:', data);
+            context.res = {
+                status: response.status,
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Content-Type': 'application/json'
+                },
+                body: {
+                    error: 'Token exchange failed',
+                    details: data.error_description || data.error
+                }
+            };
+            return;
+        }
+
+        context.log('Token exchange successful');
+
+        // Return the Graph API access token
+        context.res = {
+            status: 200,
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Content-Type': 'application/json'
+            },
+            body: {
+                accessToken: data.access_token,
+                expiresIn: data.expires_in,
+                tokenType: data.token_type
+            }
+        };
+
+    } catch (error) {
+        context.log.error('Unexpected error:', error);
+        context.res = {
+            status: 500,
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Content-Type': 'application/json'
+            },
+            body: {
+                error: 'Internal server error',
+                message: error.message
+            }
+        };
+    }
+};

--- a/azure-function/host.json
+++ b/azure-function/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "maxTelemetryItemsPerSecond": 20
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/azure-function/local.settings.json
+++ b/azure-function/local.settings.json
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "AZURE_TENANT_ID": "your-tenant-id-here",
+    "AZURE_CLIENT_ID": "your-client-id-here",
+    "AZURE_CLIENT_SECRET": "your-client-secret-here"
+  }
+}

--- a/azure-function/package.json
+++ b/azure-function/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "student-retention-token-exchange",
+  "version": "1.0.0",
+  "description": "Azure Function to exchange Office SSO tokens for Microsoft Graph API tokens",
+  "main": "index.js",
+  "scripts": {
+    "start": "func start",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}


### PR DESCRIPTION
Create serverless function to handle OAuth2 On-Behalf-Of flow for converting Office SSO tokens to Microsoft Graph API tokens. This enables the Individual mode email sending feature to work without requiring Power Automate Premium.

Function details:
- Exchanges Office SSO token for Graph API token with Mail.Send scope
- Uses OAuth2 OBO flow with Azure AD
- Handles CORS for browser requests
- Deployed to Azure Functions (Canada Central)
- Requires environment variables: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET

Endpoint: POST /api/exchange-token
Request: { "token": "office-sso-token" }
Response: { "accessToken": "graph-token", "expiresIn": 3600 }