### PR TITLE
Fix PKCE error by switching to implicit flow for consent

### DIFF
--- a/consent-callback.html
+++ b/consent-callback.html
@@ -27,10 +27,16 @@
 
     <script>
         Office.onReady(() => {
-            const urlParams = new URLSearchParams(window.location.search);
-            const code = urlParams.get('code');
-            const error = urlParams.get('error');
-            const errorDescription = urlParams.get('error_description');
+            // Implicit flow returns data in URL fragment (after #)
+            const hash = window.location.hash.substring(1);
+            const params = new URLSearchParams(hash);
+
+            // Also check query params for errors
+            const queryParams = new URLSearchParams(window.location.search);
+
+            const idToken = params.get('id_token');
+            const error = params.get('error') || queryParams.get('error');
+            const errorDescription = params.get('error_description') || queryParams.get('error_description');
 
             if (error) {
                 document.getElementById('message').innerHTML =
@@ -42,14 +48,14 @@
                     error: error,
                     description: errorDescription
                 }));
-            } else if (code) {
+            } else if (idToken) {
                 document.getElementById('message').innerHTML =
                     `<div class="success">✓ Consent granted! Closing window...</div>`;
 
-                // Send success back to parent
+                // Send success back to parent (we don't need the token, just confirmation)
                 Office.context.ui.messageParent(JSON.stringify({
                     status: 'success',
-                    code: code
+                    consented: true
                 }));
             } else {
                 document.getElementById('message').innerHTML =

--- a/consent-dialog.html
+++ b/consent-dialog.html
@@ -39,17 +39,19 @@
         Office.onReady(() => {
             const urlParams = new URLSearchParams(window.location.search);
             const clientId = '71f37f39-a330-413a-be61-0baa5ce03ea3';
-            const redirectUri = encodeURIComponent(window.location.origin + '/Student-Retention-Add-in/consent-callback.html');
-            const scope = encodeURIComponent('api://vsblanco.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user offline_access');
+            const redirectUri = encodeURIComponent('https://vsblanco.github.io/Student-Retention-Add-in/consent-callback.html');
+            const scope = encodeURIComponent('api://vsblanco.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user');
 
-            // Build Microsoft OAuth URL
+            // Build Microsoft OAuth URL - using id_token (implicit flow) just to trigger consent
+            // We don't actually use the token - we just need the user to consent
             const authUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?` +
                 `client_id=${clientId}` +
-                `&response_type=code` +
+                `&response_type=id_token` +
                 `&redirect_uri=${redirectUri}` +
-                `&response_mode=query` +
-                `&scope=${scope}` +
-                `&prompt=consent`;
+                `&response_mode=fragment` +
+                `&scope=openid ${scope}` +
+                `&prompt=consent` +
+                `&nonce=${Math.random().toString(36)}`;
 
             // Redirect to Microsoft consent page
             window.location.href = authUrl;


### PR DESCRIPTION
Change OAuth consent dialog from authorization code flow to implicit flow (id_token) to avoid PKCE requirement. We only need user consent, not an authorization code to exchange.

Changes:
- consent-dialog.html: Use response_type=id_token instead of code
- Use response_mode=fragment (implicit flow standard)
- Add nonce for security
- consent-callback.html: Parse token from URL fragment (#) not query
- Handle both fragment and query params for error cases

This avoids AADSTS9002325 error (PKCE required for code redemption) while still triggering proper consent prompt. After consent, we just need confirmation - then we get a fresh SSO token from Office which will include the newly granted permissions.

Implicit flow doesn't require code exchange or PKCE, making it simpler for consent-only scenarios.