### PR TITLE
Standardize on SyStudentId with Student Number fallback for History

### DIFF
--- a/react/src/components/utility/ColumnMapping.jsx
+++ b/react/src/components/utility/ColumnMapping.jsx
@@ -5,7 +5,7 @@ export const Sheets = {
 
 export const COLUMN_ALIASES = {
   StudentName: ['Student Name', 'Student'],
-  ID: ['Student ID', 'Student Number','Student identifier'],
+  ID: ['Student ID', 'SyStudentID', 'Student Number','Student identifier'],
   Gender: ['Gender'],
   Phone: ['Phone Number', 'Contact'],
   CreatedBy: ['Created By', 'Author', 'Advisor'],
@@ -38,7 +38,7 @@ export const COLUMN_ALIASES_HISTORY = {
   comment: ['Comment', 'Notes', 'History', 'Entry'],
   createdBy: ['Created By', 'Author', 'Advisor'],
   tag: ['Tag', 'Category', 'Type','Tags'],
-  StudentID: ['Student ID', 'Student Number','Student identifier'],
+  StudentID: ['Student ID', 'SyStudentID', 'Student Number','Student identifier'],
   commentID: ['Comment ID', 'History ID', 'Entry ID','commentID']
   // Add more aliases as needed for history columns
 };


### PR DESCRIPTION
Update History filtering to prefer SyStudentId (ID) while maintaining backwards compatibility with Student Number. This ensures that:
- New comments created via Outreach or History tab use SyStudentId
- Old comments created with Student Number are still displayed
- Both identifier types are recognized in column mappings

Changes:
- Update loadHistory() to load all history and filter by both ID types
- Add SyStudentID to column aliases for ID and StudentID fields
- Update auto-loader to trigger on both ID and StudentNumber changes
- Maintain cache lookup compatibility with StudentNumber