### PR TITLE
Fix history filtering to match against both student identifiers

### DIFF
--- a/react/src/components/studentView/StudentView.jsx
+++ b/react/src/components/studentView/StudentView.jsx
@@ -180,27 +180,27 @@ function StudentView({ onReady, user }) {
 
                     // Filter to match either SyStudentId (preferred) or StudentNumber (fallback)
                     const filtered = res.data.filter(entry => {
-                        // Use case-insensitive lookup for both ID fields
-                        const entryId = getCaseInsensitive(entry, [
+                        // Get the identifier value from the history entry
+                        // This could be in any of these columns: SyStudentId, Student Identifier, Student Number, etc.
+                        const entryIdValue = getCaseInsensitive(entry, [
                             'ID',
                             'Student ID',
                             'SyStudentID',
                             'Student Identifier',
-                            'StudentID'
-                        ]);
-                        const entryNumber = getCaseInsensitive(entry, [
-                            'Student Number',
+                            'StudentID',
+                            'Student Number',  // Also check Student Number column for backwards compatibility
                             'StudentNumber'
                         ]);
 
-                        // Match by SyStudentId first, then StudentNumber
-                        // Use loose equality (==) to handle string/number mismatches
-                        const matchById = studentId && entryId && (entryId == studentId);
-                        const matchByNumber = studentNumber && entryNumber && (entryNumber == studentNumber);
-                        const matches = matchById || matchByNumber;
+                        if (!entryIdValue) return false;
+
+                        // Match if the entry's identifier matches EITHER the student's SyStudentId OR StudentNumber
+                        // This ensures we find entries regardless of which column name is used in the History sheet
+                        const matches = (studentId && entryIdValue == studentId) ||
+                                       (studentNumber && entryIdValue == studentNumber);
 
                         if (matches) {
-                            console.log('MATCH FOUND:', { entryId, entryNumber, studentId, studentNumber });
+                            console.log('MATCH FOUND:', { entryIdValue, studentId, studentNumber });
                         }
 
                         return matches;


### PR DESCRIPTION
Consolidate ID field lookups to check a single value against both student identifiers. Now searches for the identifier in ANY column (SyStudentId, Student Identifier, Student Number, etc.) and matches it against BOTH the active student's SyStudentId AND StudentNumber.

This fixes the issue where:
- History sheet with 'SyStudentId' column only matched by SyStudentId
- History sheet with 'Student Number' column only matched by StudentNumber

Now it works regardless of which column name is used in the History sheet, and matches entries as long as they match EITHER identifier.