### PR TITLE
Fix ping/pong handler to use SRK_PING instead of SRK_TASKPANE_PING

### DIFF
--- a/background-services/background-service.js
+++ b/background-services/background-service.js
@@ -919,18 +919,6 @@ async function transferMasterList() {
  */
 function setupPingResponseListener() {
     window.addEventListener("message", (event) => {
-        if (event.data && event.data.type === "SRK_TASKPANE_PING") {
-            console.log('🏓 Received ping from Chrome extension taskpane, sending pong...');
-
-            // Send pong response back to extension
-            window.postMessage({
-                type: "SRK_TASKPANE_PONG",
-                timestamp: new Date().toISOString()
-            }, "*");
-
-            console.log('✅ Pong sent to Chrome extension');
-        }
-
         if (event.data && event.data.type === "SRK_PING") {
             console.log('🏓 Received SRK_PING from Chrome extension, sending pong...');
 


### PR DESCRIPTION
Replaced SRK_TASKPANE_PING/SRK_TASKPANE_PONG with the standard SRK_PING/SRK_PONG message types for Chrome extension communication. This unifies the ping/pong protocol to use a single message type.