### PR TITLE
Fix assignments tab missing data display

### DIFF
--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -7,7 +7,7 @@ export const defaultColumns =[
 	{ name: 'Student Number', alias: ['Student Numbers','Issued ID'], hidden: true },
 	{ name: 'SyStudentId', alias: ['student sis'], hidden: true, identifier: true },
 	{ name: 'Student Name', alias: ['Student']},
-	{ name: 'Gradebook', alias: ['Gradelink','gradeBookLink'], static: true, identifier: true, format: ['=HYPERLINK']},
+	{ name: 'Gradebook', alias: ['Gradelink', 'gradeBookLink', 'Grade Book'], static: true, identifier: true, format: ['=HYPERLINK']},
 	{ name: 'ProgramVersion', alias: ['Program','ProgVersDescrip'] },
 	{ name: 'Shift', alias: ['ShiftDescrip'] },
 	{ name: 'LDA', alias: ['Last Date of Attendance','Date of Attendance', 'CurrentLDA'], format: ['MM/DD/YYYY']},

--- a/react/src/components/studentView/StudentView.jsx
+++ b/react/src/components/studentView/StudentView.jsx
@@ -218,7 +218,7 @@ function StudentView({ onReady, user }) {
     const loadAssignments = () => {
         if (!activeStudentState || !activeStudentState.Gradebook) return;
         if (!availableTabs.assignments) return;
-        loadSheet('Missing Assignments', 'gradeBookLink', activeStudentState.Gradebook)
+        loadSheet('Missing Assignments', 'Gradebook', activeStudentState.Gradebook)
             .then((res) => { setAssignments(res.data); })
             .catch((err) => console.error(err));
     };

--- a/react/src/components/studentView/Tabs/Assignments.jsx
+++ b/react/src/components/studentView/Tabs/Assignments.jsx
@@ -22,7 +22,7 @@ export const COLUMN_ALIASES_ASSIGNMENTS = {
   score: ['Score', 'Points'],
   submissionLink: ['Submission Link', 'Submission', 'Submit Link'],
   assignmentLink: ['Assignment Link', 'Assignment URL', 'Assignment Page', 'Link'],
-  gradebook: ['Gradebook','gradeBookLink'],
+  gradebook: ['Gradebook', 'gradeBookLink', 'Grade Book'],
   submission: ['submission', 'Submitted', 'Submission Status', 'Is Submitted']
 };
 

--- a/react/src/components/utility/ColumnMapping.jsx
+++ b/react/src/components/utility/ColumnMapping.jsx
@@ -17,7 +17,7 @@ export const COLUMN_ALIASES = {
   Grade: ['Current Grade', 'Grade %', 'Grade'],
   LDA: ['Last Date of Attendance', 'LDA'],
   DaysOut: ['Days Out'],
-  Gradebook: ['Gradebook','gradeBookLink'],
+  Gradebook: ['Gradebook', 'gradeBookLink', 'Grade Book'],
   MissingAssignments: ['Missing Assignments', 'Missing'],
   Outreach: ['Outreach', 'Comments', 'Notes', 'Comment']
   // You can add more aliases for other columns here
@@ -30,7 +30,7 @@ export const COLUMN_ALIASES_ASSIGNMENTS = {
   score: ['Score', 'Points'],
   submissionLink: ['Submission Link', 'Submission', 'Submit Link'],
   assignmentLink: ['Assignment Link', 'Assignment URL', 'Assignment Page', 'Link'],
-  Gradebook: ['Gradebook','gradeBookLink'],
+  Gradebook: ['Gradebook', 'gradeBookLink', 'Grade Book'],
 };
 
 export const COLUMN_ALIASES_HISTORY = {


### PR DESCRIPTION
Updated column aliases across the codebase to recognize 'Grade Book' (with space) in addition to 'Gradebook' and 'gradeBookLink'. Changed the loadAssignments identifier from 'gradeBookLink' to 'Gradebook' to properly filter assignments when the column is named 'Grade Book'.

The code already handles Excel HYPERLINK formulas correctly through the Office.js API, which automatically extracts the URL value from HYPERLINK cells.

Changes:
- Assignments.jsx: Added 'Grade Book' to gradebook column aliases
- StudentView.jsx: Changed loadSheet identifier from 'gradeBookLink' to 'Gradebook'
- ColumnMapping.jsx: Added 'Grade Book' to both COLUMN_ALIASES and COLUMN_ALIASES_ASSIGNMENTS
- DefaultSettings.jsx: Added 'Grade Book' to Gradebook column aliases