### PR TITLE
Extract URLs from HYPERLINK formulas in loadSheet for proper matching

### DIFF
--- a/react/src/components/utility/ExcelAPI.jsx
+++ b/react/src/components/utility/ExcelAPI.jsx
@@ -609,6 +609,18 @@ export async function loadSheet(sheet, identifierColumn = null, identifierRow = 
                         for (let c = 0; c < columnCount; c++) {
                             const headerKey = headerNames[c] !== "" ? headerNames[c] : `Column${c}`;
                             rowObj[headerKey] = (row[c] !== undefined) ? row[c] : null;
+
+                            // Extract URL from HYPERLINK formula if present
+                            if (c < rowFormulas.length) {
+                                const formula = rowFormulas[c];
+                                if (formula && typeof formula === 'string') {
+                                    const match = formula.match(hyperlinkRegex);
+                                    if (match && match[1]) {
+                                        // Store URL as "{ColumnName} Link"
+                                        rowObj[`${headerKey} Link`] = match[1];
+                                    }
+                                }
+                            }
                         }
                         let rawKey = row[idColIdx];
                         // Check if identifier column has a HYPERLINK formula - extract URL
@@ -629,10 +641,23 @@ export async function loadSheet(sheet, identifierColumn = null, identifierRow = 
                     data = [];
                     for (let r = 1; r < values.length; r++) {
                         const row = values[r] || [];
+                        const rowFormulas = formulas[r] || [];
                         const rowObj = {};
                         for (let c = 0; c < columnCount; c++) {
                             const headerKey = headerNames[c] !== "" ? headerNames[c] : `Column${c}`;
                             rowObj[headerKey] = (row[c] !== undefined) ? row[c] : null;
+
+                            // Extract URL from HYPERLINK formula if present
+                            if (c < rowFormulas.length) {
+                                const formula = rowFormulas[c];
+                                if (formula && typeof formula === 'string') {
+                                    const match = formula.match(hyperlinkRegex);
+                                    if (match && match[1]) {
+                                        // Store URL as "{ColumnName} Link"
+                                        rowObj[`${headerKey} Link`] = match[1];
+                                    }
+                                }
+                            }
                         }
                         data.push(rowObj);
                     }


### PR DESCRIPTION
Updated ExcelAPI.loadSheet() to extract URLs from all HYPERLINK formulas and store them as separate properties with " Link" suffix. This makes assignment titles and missing badges properly clickable.

The issue:
- "Assignment" column has =HYPERLINK("url", "Title") formula
- "Submission" column has =HYPERLINK("url", "Missing") formula
- loadSheet only read display text, so URLs weren't available
- Clicking missing badge went to relative URL "/Missing"
- Assignment titles weren't clickable

The fix:
- For each cell with HYPERLINK formula, extract the URL
- Store as separate property: "{ColumnName} Link"
- Example: "Assignment" → "Assignment" (title) + "Assignment Link" (URL)
- Example: "Submission" → "Submission" (text) + "Submission Link" (URL)

Column alias mapping now works correctly:
- assignmentLink: ['Assignment Link', ...] → matches "Assignment Link"
- submissionLink: ['Submission Link', ...] → matches "Submission Link"
- title: ['Assignment Title', 'Title', 'Assignment'] → matches "Assignment"
- submission: ['submission', 'Submitted', ...] → matches "Submission"

Now both assignment titles and missing badges are properly clickable with correct URLs to Canvas assignment and submission pages.

Changes:
- ExcelAPI.jsx: Extract URL from HYPERLINK formulas for all columns
- ExcelAPI.jsx: Store URLs as "{ColumnName} Link" properties