### PR TITLE
Fix submissionLink alias to map to URL instead of display text

### DIFF
--- a/react/src/components/studentView/Tabs/Assignments.jsx
+++ b/react/src/components/studentView/Tabs/Assignments.jsx
@@ -20,7 +20,7 @@ export const COLUMN_ALIASES_ASSIGNMENTS = {
   title: ['Assignment Title', 'Title', 'Assignment'],
   dueDate: ['Due Date', 'Deadline'],
   score: ['Score', 'Points'],
-  submissionLink: ['Submission Link', 'Submission', 'Submit Link'],
+  submissionLink: ['Submission Link', 'Submit Link'],
   assignmentLink: ['Assignment Link', 'Assignment URL', 'Assignment Page', 'Link'],
   gradebook: ['Gradebook', 'gradeBookLink', 'Grade Book'],
   submission: ['submission', 'Submitted', 'Submission Status', 'Is Submitted']


### PR DESCRIPTION
Removed 'Submission' from submissionLink aliases to prevent it from matching the display text column instead of the URL column.

The issue:
- loadSheet creates both "Submission" (display text "Missing") and "Submission Link" (extracted URL) properties
- submissionLink aliases included 'Submission', which matched first
- This caused map.submissionLink to map to "Submission" (display text)
- Clicking missing badge used "Missing" as href, creating relative URL: https://vsblanco.github.io/.../react/dist/Missing

The fix:
- Remove 'Submission' from submissionLink aliases
- Now submissionLink maps to "Submission Link" (URL) ✓
- submission maps to "Submission" (missing indicator) ✓

Changes:
- Assignments.jsx: Updated submissionLink aliases from ['Submission Link', 'Submission', 'Submit Link'] to ['Submission Link', 'Submit Link']