### PR TITLE
Fix getRangeByIndexes - use sheet instead of bodyRange

### DIFF
--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -742,8 +742,11 @@ async function writeTable(context, sheet, startRow, tableName, outputColumns, pr
         }
 
         // Apply cell color ranges (merged ranges = fewer API calls)
+        // Use sheet.getRangeByIndexes with absolute positions (bodyRange doesn't have this method)
+        // Body starts at startRow + 1 (after header)
         for (const op of cellColorOps) {
-            const range = bodyRange.getRangeByIndexes(op.rowIdx, op.startCol, 1, op.endCol - op.startCol + 1);
+            const absoluteRow = startRow + 1 + op.rowIdx;
+            const range = sheet.getRangeByIndexes(absoluteRow, op.startCol, 1, op.endCol - op.startCol + 1);
             range.format.fill.color = op.color;
             if (op.strikethrough) {
                 range.format.font.strikethrough = true;


### PR DESCRIPTION
getRangeByIndexes() is a Worksheet method, not a Range method. Changed to use sheet.getRangeByIndexes() with absolute row positions calculated as: startRow + 1 (header) + rowIdx.

https://claude.ai/code/session_01AH2NhjvgbnYyuiPqHCv4f8