### PR TITLE
Add rich text editors to value mapping result boxes

### DIFF
--- a/personalized-email/modal.js
+++ b/personalized-email/modal.js
@@ -683,6 +683,7 @@ export default class ModalManager {
             <div class="mt-2">
                 <span class="text-sm text-gray-700 block mb-1">Then use</span>
                 <div class="then-editor-container bg-white rounded-md"></div>
+                <p class="text-xs text-gray-400 mt-1">Tip: Click in the editor above, then use parameter buttons to insert nested parameters like {Grade}</p>
             </div>
         `;
 
@@ -696,6 +697,13 @@ export default class ModalManager {
         // Initialize Quill editor for the result box
         const editorContainer = row.querySelector('.then-editor-container');
         const quillInstance = new Quill(editorContainer, MINI_QUILL_EDITOR_CONFIG);
+
+        // Track focus to allow parameter insertion via parameter buttons
+        quillInstance.on('selection-change', (range) => {
+            if (range) {
+                this.appContext.setLastFocusedInput(quillInstance);
+            }
+        });
 
         // Set initial value (handle both plain text and HTML)
         if (mapping.then) {

--- a/personalized-email/personalized-email.html
+++ b/personalized-email/personalized-email.html
@@ -71,6 +71,26 @@
         .mini-quill-editor .ql-toolbar {
             padding: 4px 8px;
         }
+        /* Styles for Quill editors in value mapping result boxes */
+        .then-editor-container .ql-container {
+            border-radius: 0 0 0.375rem 0.375rem;
+            font-size: 0.875rem;
+        }
+        .then-editor-container .ql-toolbar {
+            border-radius: 0.375rem 0.375rem 0 0;
+            padding: 4px 8px;
+            background-color: #f9fafb;
+        }
+        .then-editor-container .ql-editor {
+            padding: 8px 12px;
+            min-height: 50px;
+            max-height: 120px;
+            overflow-y: auto;
+        }
+        .then-editor-container .ql-editor.ql-blank::before {
+            color: #9ca3af;
+            font-style: normal;
+        }
         /* Chevron icon for collapsible sections */
         .chevron-icon {
             transition: transform 0.2s ease-in-out;

--- a/personalized-email/personalized-email.js
+++ b/personalized-email/personalized-email.js
@@ -238,6 +238,7 @@ Office.onReady((info) => {
         
         const appContext = {
             quill,
+            setLastFocusedInput: (input) => { lastFocusedInput = input; },
             getStudentDataWithUI,
             getStudentDataCore: _getStudentDataCore,
             updateRecipientSelection: (newSelection, count) => {

--- a/react/src/components/personalizedEmail/modals/CustomParamModal.jsx
+++ b/react/src/components/personalizedEmail/modals/CustomParamModal.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { MAPPING_OPERATORS } from '../utils/constants';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
+import { MAPPING_OPERATORS, MINI_QUILL_EDITOR_CONFIG } from '../utils/constants';
 
 export default function CustomParamModal({ isOpen, onClose, customParameters, onSave }) {
     const [showManageModal, setShowManageModal] = useState(false);
@@ -233,15 +235,18 @@ export default function CustomParamModal({ isOpen, onClose, customParameters, on
                                                 placeholder="Value..."
                                             />
                                         </div>
-                                        <div className="flex flex-wrap items-center gap-2">
-                                            <span className="text-sm text-gray-700">Then use</span>
-                                            <input
-                                                type="text"
-                                                value={mapping.then}
-                                                onChange={(e) => handleMappingChange(index, 'then', e.target.value)}
-                                                className="flex-1 min-w-[120px] px-2 py-1 border border-gray-300 rounded-md text-sm bg-white"
-                                                placeholder="Result..."
-                                            />
+                                        <div className="mt-2">
+                                            <span className="text-sm text-gray-700 block mb-1">Then use</span>
+                                            <div className="mapping-quill-editor">
+                                                <ReactQuill
+                                                    theme="snow"
+                                                    value={mapping.then}
+                                                    onChange={(value) => handleMappingChange(index, 'then', value)}
+                                                    modules={MINI_QUILL_EDITOR_CONFIG.modules}
+                                                    placeholder="Result (with formatting)..."
+                                                    className="bg-white rounded-md"
+                                                />
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/react/src/components/personalizedEmail/utils/constants.js
+++ b/react/src/components/personalizedEmail/utils/constants.js
@@ -21,6 +21,16 @@ export const QUILL_EDITOR_CONFIG = {
     }
 };
 
+// Configuration for smaller rich text editors (value mapping result boxes)
+export const MINI_QUILL_EDITOR_CONFIG = {
+    theme: 'snow',
+    modules: {
+        toolbar: [
+            ['bold', 'italic', 'underline', 'link']
+        ]
+    }
+};
+
 // Maps internal data keys to possible column header names in the Excel sheet
 export const COLUMN_MAPPINGS = {
     StudentName: ["studentname", "student name", "Student Name", "StudentName"],

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -23,3 +23,24 @@ body {
   background-color: #ffffff;
   color: #2c3e50;
 }
+
+/* Styles for Quill editors in value mapping result boxes */
+.mapping-quill-editor .ql-container {
+  border-radius: 0 0 0.375rem 0.375rem;
+  font-size: 0.875rem;
+}
+.mapping-quill-editor .ql-toolbar {
+  border-radius: 0.375rem 0.375rem 0 0;
+  padding: 4px 8px;
+  background-color: #f9fafb;
+}
+.mapping-quill-editor .ql-editor {
+  padding: 8px 12px;
+  min-height: 50px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+.mapping-quill-editor .ql-editor.ql-blank::before {
+  color: #9ca3af;
+  font-style: normal;
+}


### PR DESCRIPTION
## Summary
Enhanced the custom parameter value mapping feature by replacing plain text inputs with rich text editors (Quill) in the "Then use" result boxes. This allows users to format mapping results with bold, italic, underline, and link support.

## Key Changes
- **Modal Manager (modal.js)**
  - Added `mappingQuillEditors` array to track Quill editor instances for each mapping row
  - Imported `MINI_QUILL_EDITOR_CONFIG` from constants
  - Updated `_addMappingRow()` to initialize Quill editors for result boxes with proper HTML/text handling
  - Modified `_getMappingsFromDOM()` to extract HTML content from Quill editors instead of plain text inputs
  - Added cleanup logic in `_resetCustomParamModal()` to properly dispose of editor instances

- **HTML Template (personalized-email.html)**
  - Added CSS styling for `.then-editor-container` with proper border radius, padding, and height constraints
  - Styled toolbar and editor content areas for consistency with existing mini editors

- **React Component (CustomParamModal.jsx)**
  - Replaced plain text input with `ReactQuill` component for mapping result fields
  - Integrated `MINI_QUILL_EDITOR_CONFIG` for consistent toolbar configuration

- **Constants (constants.js)**
  - Added new `MINI_QUILL_EDITOR_CONFIG` export with minimal toolbar (bold, italic, underline, link)
  - Configured for compact display in mapping result boxes

- **Styles (react/src/index.css)**
  - Added `.mapping-quill-editor` styles matching the HTML template styling for consistency across implementations

## Implementation Details
- Quill editors are initialized with a minimal toolbar to keep the UI compact
- Row indices are tracked via `data-rowIndex` attributes to maintain proper editor references
- HTML content is preserved when loading existing mappings (detects HTML vs plain text)
- Removed editors are marked as null to prevent errors when retrieving mapping data
- Consistent styling applied across both vanilla JS and React implementations

https://claude.ai/code/session_01D5ZNQTjiKkE66keov4qAPq