### PR TITLE
Split 'by' field into 'byName' and 'byEmail' in email payload

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -828,7 +828,8 @@ export default function PersonalizedEmail({ user, accessToken, onReady }) {
             cc: renderCCTemplate(ccPills, student),
             subject: renderTemplate(subject, student),
             body: renderTemplate(cleanBodyHtml, student),
-            by: userEmail || ''
+            byName: user || '',
+            byEmail: userEmail || ''
         })).filter(email => email.to && email.from);
     };
 
@@ -1070,7 +1071,8 @@ export default function PersonalizedEmail({ user, accessToken, onReady }) {
             cc: renderCCTemplate(ccPills, testStudent),
             subject: `[TEST] ${renderTemplate(subject, testStudent)}`,
             body: renderTemplate(cleanBodyHtml, testStudent),
-            by: userEmail || ''
+            byName: user || '',
+            byEmail: userEmail || ''
         }];
 
         setLastSentPayload(testPayload);


### PR DESCRIPTION
Replace single 'by' field with two separate fields for more flexibility:
- byName: The display name of the SSO user (e.g., "Victor Blanco")
- byEmail: The email address of the SSO user (e.g., "vblanco1@ftccollege.edu")

https://claude.ai/code/session_01V1qae2TUuHPw4SJzYgopc5