### PR TITLE
Improve DNC tag matching to handle comma-separated values

### DIFF
--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -113,9 +113,15 @@ function getRetentionMessage(sId, ldaMap, missingVal, tableContext, dncMap, next
     // Priority 1: Explicit DNC (Highest Priority - Stop everything)
     if (sId && dncMap.has(sId)) {
         const dncTag = dncMap.get(sId);
-        // Check if tag is "dnc" by itself (trimmed and lowered)
-        if (dncTag && dncTag.trim() === 'dnc') {
-            return "[Retention] DNC";
+        if (dncTag) {
+            // Split comma-separated tags and check each individually
+            const individualTags = dncTag.split(',').map(t => t.trim());
+            const hasExcludableDnc = individualTags.some(tag =>
+                tag.includes('dnc') && tag !== 'dnc - phone' && tag !== 'dnc - other phone'
+            );
+            if (hasExcludableDnc) {
+                return "[Retention] DNC";
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Enhanced the DNC (Do Not Call) tag matching logic to properly handle comma-separated tag values while excluding specific phone-related DNC variants.

## Key Changes
- Modified DNC tag validation to split comma-separated values and evaluate each tag individually
- Added logic to exclude `dnc - phone` and `dnc - other phone` tags from triggering retention exclusion
- Improved tag matching to check if a tag contains 'dnc' rather than requiring an exact match, allowing for variations while maintaining the exclusion list

## Implementation Details
- The DNC tag is now split by commas and trimmed to handle multiple tags in a single field
- Uses `Array.some()` to check if any individual tag matches the criteria: contains 'dnc' but is not one of the excluded phone variants
- This allows the system to properly handle cases where multiple DNC-related tags are stored together while respecting the specific exclusions for phone-related DNC tags

https://claude.ai/code/session_01LwAML88J39h5NPFSNEyrV6