### PR TITLE
Add Call Queue ribbon action to send selected students

### DIFF
--- a/background-services/background-service.js
+++ b/background-services/background-service.js
@@ -9,7 +9,7 @@
  * - Manages Chrome Extension Service communication
  * - Handles Master List data synchronization
  */
-import { toggleHighlight, transferData } from './ribbon-actions.js';
+import { toggleHighlight, transferData, createSendToCallQueue } from './ribbon-actions.js';
 import chromeExtensionService from '../react/src/services/chromeExtensionService.js';
 import { CONSTANTS, findColumnIndex, normalizeName, formatToLastFirst, parseDate } from './shared-utilities.js';
 
@@ -1636,6 +1636,7 @@ async function sendSheetListToExtension() {
 Office.actions.associate("toggleHighlight", toggleHighlight);
 Office.actions.associate("transferData", transferData);
 Office.actions.associate("openAnalyticsPane", openAnalyticsPane);
+Office.actions.associate("sendToCallQueue", createSendToCallQueue(chromeExtensionService));
 
 // Register autoload event handler
 Office.actions.associate("onDocumentOpen", onDocumentOpen);

--- a/background-services/ribbon-actions.js
+++ b/background-services/ribbon-actions.js
@@ -6,6 +6,88 @@
  */
 import { CONSTANTS, findColumnIndex } from './shared-utilities.js';
 
+/**
+ * Creates a sendToCallQueue ribbon action bound to the given chromeExtensionService.
+ * Reads the currently selected row(s), extracts student data, and sends it
+ * to the Chrome Extension call queue via SRK_SELECTED_STUDENTS.
+ *
+ * @param {Object} extensionService - The chromeExtensionService singleton
+ * @returns {Function} The ribbon action handler
+ */
+export function createSendToCallQueue(extensionService) {
+  return async function sendToCallQueue(event) {
+    try {
+      await Excel.run(async (context) => {
+        const sheet = context.workbook.worksheets.getActiveWorksheet();
+        const selectedRange = context.workbook.getSelectedRange();
+        selectedRange.load("rowIndex, rowCount");
+        const usedRange = sheet.getUsedRange();
+        usedRange.load(["values", "rowIndex"]);
+
+        await context.sync();
+
+        const allValues = usedRange.values;
+        const headers = allValues[0].map(h => String(h || '').toLowerCase());
+
+        // Find required columns
+        const nameColIndex = findColumnIndex(headers, CONSTANTS.STUDENT_NAME_COLS);
+        const idColIndex = findColumnIndex(headers, CONSTANTS.STUDENT_ID_COLS);
+        const phoneColIndex = findColumnIndex(headers, CONSTANTS.COLUMN_MAPPINGS.primaryPhone);
+        const otherPhoneColIndex = findColumnIndex(headers, CONSTANTS.COLUMN_MAPPINGS.otherPhone);
+
+        if (nameColIndex === -1 && idColIndex === -1) {
+          console.error("sendToCallQueue: Could not find student name or ID columns.");
+          return;
+        }
+
+        const selectionStartRow = selectedRange.rowIndex;
+        const selectionRowCount = selectedRange.rowCount;
+        const dataStartRow = usedRange.rowIndex;
+
+        const students = [];
+
+        for (let i = 0; i < selectionRowCount; i++) {
+          const absoluteRow = selectionStartRow + i;
+          const relativeRow = absoluteRow - dataStartRow;
+
+          // Skip header row and rows outside used range
+          if (relativeRow <= 0) continue;
+          if (relativeRow >= allValues.length) continue;
+
+          const rowData = allValues[relativeRow];
+
+          const name = nameColIndex !== -1 ? String(rowData[nameColIndex] || '') : '';
+          const syStudentId = idColIndex !== -1 ? String(rowData[idColIndex] || '') : '';
+          const phone = phoneColIndex !== -1 ? String(rowData[phoneColIndex] || '') : '';
+          const otherPhone = otherPhoneColIndex !== -1 ? String(rowData[otherPhoneColIndex] || '') : '';
+
+          // Skip rows with no meaningful data
+          if (!name && !syStudentId) continue;
+
+          students.push({ name, syStudentId, phone, otherPhone });
+        }
+
+        if (students.length === 0) {
+          console.log("sendToCallQueue: No valid student rows in selection.");
+          return;
+        }
+
+        extensionService.sendSelectedStudents(students);
+        console.log(`sendToCallQueue: Sent ${students.length} student(s) to call queue.`);
+      });
+    } catch (error) {
+      console.error("Error in sendToCallQueue: " + error);
+      if (error instanceof OfficeExtension.Error) {
+        console.error("Debug info: " + JSON.stringify(error.debugInfo));
+      }
+    } finally {
+      if (event) {
+        event.completed();
+      }
+    }
+  };
+}
+
 let transferDialog = null;
 
 /**

--- a/manifest.xml
+++ b/manifest.xml
@@ -121,6 +121,21 @@
                     <SourceLocation resid="PersonalizedEmail.Url"/>
                   </Action>
                 </Control>
+                <Control xsi:type="Button" id="CallQueueButton">
+                  <Label resid="CallQueueButton.Label"/>
+                  <Supertip>
+                    <Title resid="CallQueueButton.Label"/>
+                    <Description resid="CallQueueButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="CallIcon.16x16"/>
+                    <bt:Image size="32" resid="CallIcon.32x32"/>
+                    <bt:Image size="80" resid="CallIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>sendToCallQueue</FunctionName>
+                  </Action>
+                </Control>
               </Group>
               <Group id="StudentViewGroup">
                 <Label resid="StudentViewGroup.Label"/>
@@ -168,6 +183,9 @@
         <bt:Image id="EmailIcon.16x16" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
         <bt:Image id="EmailIcon.32x32" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
         <bt:Image id="EmailIcon.80x80" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
+        <bt:Image id="CallIcon.16x16" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/contacted-icon.png"/>
+        <bt:Image id="CallIcon.32x32" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/contacted-icon.png"/>
+        <bt:Image id="CallIcon.80x80" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/contacted-icon.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
@@ -188,6 +206,7 @@
         <bt:String id="CreateLdaButton.Label" DefaultValue="Create LDA"/>
         <bt:String id="SettingsButton.Label" DefaultValue="Settings"/>
         <bt:String id="PersonalizedEmailButton.Label" DefaultValue="Send Emails"/>
+        <bt:String id="CallQueueButton.Label" DefaultValue="Call"/>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="Your add-in loaded successfully. Go to the 'Retention' tab to get started."/>
@@ -195,6 +214,7 @@
         <bt:String id="CreateLdaButton.Tooltip" DefaultValue="Creates a new LDA sheet for the current date."/>
         <bt:String id="SettingsButton.Tooltip" DefaultValue="Click to configure add-in settings."/>
         <bt:String id="PersonalizedEmailButton.Tooltip" DefaultValue="Opens a task pane to send a personalized email to the selected student."/>
+        <bt:String id="CallQueueButton.Tooltip" DefaultValue="Sends selected student(s) to the Chrome Extension call queue."/>
       </bt:LongStrings>
     </Resources>
 


### PR DESCRIPTION
## Summary
This PR adds a new "Call" ribbon button that allows users to send selected student data to the Chrome Extension call queue. The feature integrates with the existing extension service to streamline the workflow for managing student outreach.

## Key Changes
- **New `createSendToCallQueue` function** in `ribbon-actions.js`: Implements the core logic to extract student data from selected Excel rows and send it to the Chrome Extension via the extension service
  - Reads student name, ID, and phone contact information from the active worksheet
  - Validates that at least one meaningful data field exists per row
  - Handles row indexing correctly to account for headers and used range offsets
  - Includes comprehensive error handling and logging

- **UI Integration**: Added "Call" button to the ribbon in `manifest.xml`
  - Button includes label, tooltip, and icon assets (16x16, 32x32, 80x80)
  - Positioned in the existing action group alongside other student contact features
  - Wired to execute the `sendToCallQueue` function

- **Service Registration**: Updated `background-service.js` to register the new action with Office
  - Imports and associates the `createSendToCallQueue` function with the Chrome Extension service

## Implementation Details
- The function uses Excel's context API to safely access worksheet data and selection information
- Student data extraction is defensive, handling missing columns gracefully by checking column indices
- Empty rows and rows with no name/ID are skipped to avoid sending incomplete data
- Proper event completion handling ensures the ribbon action completes successfully
- Comprehensive error logging for debugging purposes

https://claude.ai/code/session_01Kxe2JokWKY5h4XWo56CCPC