### PR TITLE
Add autoCall flag to ribbon call button payload

### DIFF
--- a/background-services/ribbon-actions.js
+++ b/background-services/ribbon-actions.js
@@ -72,8 +72,8 @@ export function createSendToCallQueue(extensionService) {
           return;
         }
 
-        extensionService.sendSelectedStudents(students);
-        console.log(`sendToCallQueue: Sent ${students.length} student(s) to call queue.`);
+        extensionService.sendSelectedStudents(students, null, true);
+        console.log(`sendToCallQueue: Sent ${students.length} student(s) to call queue (autoCall).`);
       });
     } catch (error) {
       console.error("Error in sendToCallQueue: " + error);

--- a/react/src/services/chromeExtensionService.js
+++ b/react/src/services/chromeExtensionService.js
@@ -1012,8 +1012,9 @@ class ChromeExtensionService {
    * Send selected student data to the Chrome extension
    * @param {Array|Object} students - Single student object or array of students
    * @param {string|null} directPhone - Phone number from a directly-selected cell (fast-path)
+   * @param {boolean} autoCall - Whether the extension should automatically initiate the call
    */
-  sendSelectedStudents(students, directPhone = null) {
+  sendSelectedStudents(students, directPhone = null, autoCall = false) {
     // Normalize to array format
     const studentArray = Array.isArray(students) ? students : [students];
 
@@ -1031,7 +1032,8 @@ class ChromeExtensionService {
         students: payload,
         count: payload.length,
         timestamp: new Date().toISOString(),
-        directPhone: directPhone || null  // Phone number from single cell selection
+        directPhone: directPhone || null,  // Phone number from single cell selection
+        autoCall: autoCall  // Auto-initiate call (used by ribbon call button)
       }
     };
 


### PR DESCRIPTION
The ribbon's sendToCallQueue now passes autoCall=true via sendSelectedStudents, telling the extension to auto-initiate the call. Student view selections continue sending autoCall=false.

https://claude.ai/code/session_01Kxe2JokWKY5h4XWo56CCPC