### PR TITLE
Refactor workbook settings initialization with auto-defaults

### DIFF
--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -8,6 +8,9 @@
  *         API calls from thousands to hundreds per batch. This dramatically speeds up formatting.
  */
 
+import { getWorkbookSettings } from '../utility/getSettings';
+import { defaultColumns } from '../settings/DefaultSettings';
+
 // Hardcoded sheet names (unless these are also settings, usually they are static)
 const SHEET_NAMES = {
     MASTER_LIST: "Master List",
@@ -166,12 +169,15 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
         // --- STEP 1: Validate Settings & Environment ---
         if (onProgress) onProgress('validate', 'active');
         
-        let workbookSettings = {};
-        if (typeof Office !== 'undefined' && Office.context && Office.context.document) {
-             const settings = Office.context.document.settings.get('workbookSettings');
-             if (settings && typeof settings === 'object') {
-                 workbookSettings = settings;
-             }
+        const workbookSettings = getWorkbookSettings(defaultColumns);
+
+        // If columns were auto-initialized from defaults, persist them so Settings tab stays in sync
+        if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
+            const existing = Office.context.document.settings.get('workbookSettings');
+            if (!existing || !Array.isArray(existing.columns) || existing.columns.length === 0) {
+                Office.context.document.settings.set('workbookSettings', workbookSettings);
+                Office.context.document.settings.saveAsync(() => {});
+            }
         }
 
         const settings = {
@@ -181,13 +187,9 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
             includeLDATag: userOverrides.includeLDATag ?? true,
             includeDNCTag: userOverrides.includeDNCTag ?? true,
             sheetNameMode: userOverrides.sheetNameMode ?? 'date',
-            columns: workbookSettings.columns || [],
+            columns: workbookSettings.columns,
             advisorAssignment: userOverrides.advisorAssignment ?? { enabled: false, advisors: [] }
         };
-
-        if (settings.columns.length === 0) {
-            throw new Error("No column settings found. Please configure columns in the Settings tab first.");
-        }
 
         await Excel.run(async (context) => {
             const sheets = context.workbook.worksheets;


### PR DESCRIPTION
## Summary
Refactored the workbook settings initialization logic to use a new `getWorkbookSettings()` utility function that provides sensible defaults from `defaultColumns`. The change also adds automatic persistence of auto-initialized settings back to the Office document to keep the Settings tab in sync.

## Key Changes
- Extracted hardcoded settings retrieval logic into a reusable `getWorkbookSettings()` utility function
- Imported `defaultColumns` from settings to provide fallback column configuration
- Added automatic persistence of settings when columns are auto-initialized from defaults, ensuring the Settings tab reflects the current state
- Removed the error throw when no columns are configured, allowing the process to proceed with default columns instead
- Simplified the settings object initialization by removing the fallback `|| []` since `getWorkbookSettings()` now guarantees a valid columns array

## Implementation Details
- The new settings persistence logic only writes to Office document settings if columns haven't been explicitly configured yet, preventing unnecessary overwrites
- Uses `saveAsync()` callback to ensure settings are persisted to the workbook
- Maintains backward compatibility by checking for existing settings before applying defaults

https://claude.ai/code/session_01NnktnZduVWF4M8yQY7Z8sN