### PR TITLE
Add Report Generation side panel feature

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -89,6 +89,22 @@
                   <bt:Image size="32" resid="Icon.32x32"/>
                   <bt:Image size="80" resid="Icon.80x80"/>
                 </Icon>
+                <Control xsi:type="Button" id="GenerateReportButton">
+                  <Label resid="GenerateReportButton.Label"/>
+                  <Supertip>
+                    <Title resid="GenerateReportButton.Label"/>
+                    <Description resid="GenerateReportButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="ReportIcon.16x16"/>
+                    <bt:Image size="32" resid="ReportIcon.32x32"/>
+                    <bt:Image size="80" resid="ReportIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ReportGenerationPane</TaskpaneId>
+                    <SourceLocation resid="ReportGeneration.Url"/>
+                  </Action>
+                </Control>
                 <Control xsi:type="Button" id="CreateLdaButton">
                   <Label resid="CreateLdaButton.Label"/>
                   <Supertip>
@@ -186,6 +202,9 @@
         <bt:Image id="CallIcon.16x16" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
         <bt:Image id="CallIcon.32x32" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
         <bt:Image id="CallIcon.80x80" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
+        <bt:Image id="ReportIcon.16x16" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/icon-16.png"/>
+        <bt:Image id="ReportIcon.32x32" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/icon-32.png"/>
+        <bt:Image id="ReportIcon.80x80" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/icon-80.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
@@ -195,6 +214,7 @@
         <bt:Url id="CreateLdaDialog.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/react/dist/index.html?page=create-lda"/>
         <bt:Url id="WelcomeDialog.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/welcome-dialog.html"/>
         <bt:Url id="PersonalizedEmail.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/react/dist/index.html?page=personalized-email"/>
+        <bt:Url id="ReportGeneration.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/react/dist/index.html?page=report-generation"/>
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with the Retention Add-in!"/>
@@ -207,6 +227,7 @@
         <bt:String id="SettingsButton.Label" DefaultValue="Settings"/>
         <bt:String id="PersonalizedEmailButton.Label" DefaultValue="Send Emails"/>
         <bt:String id="CallQueueButton.Label" DefaultValue="Call"/>
+        <bt:String id="GenerateReportButton.Label" DefaultValue="Generate Report"/>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="Your add-in loaded successfully. Go to the 'Retention' tab to get started."/>
@@ -215,6 +236,7 @@
         <bt:String id="SettingsButton.Tooltip" DefaultValue="Click to configure add-in settings."/>
         <bt:String id="PersonalizedEmailButton.Tooltip" DefaultValue="Opens a task pane to send a personalized email to the selected student."/>
         <bt:String id="CallQueueButton.Tooltip" DefaultValue="Sends selected student(s) to the Chrome Extension call queue."/>
+        <bt:String id="GenerateReportButton.Tooltip" DefaultValue="Opens the report generation panel to create and export retention reports."/>
       </bt:LongStrings>
     </Resources>
 

--- a/react/src/App.jsx
+++ b/react/src/App.jsx
@@ -5,6 +5,7 @@ import About from './components/about/About.jsx';
 import Settings from './components/settings/Settings.jsx';
 import LDAManager from './components/createLDA/LDAManager.jsx';
 import PersonalizedEmail from './components/personalizedEmail/PersonalizedEmail.jsx';
+import ReportGeneration from './components/reportGeneration/ReportGeneration.jsx';
 import Welcome from './components/welcomeScreen/Welcome.jsx'; // Import the Welcome component
 import chromeExtensionService from './services/chromeExtensionService.js'; // Chrome Extension Service
 import { ToastContainer, Slide } from 'react-toastify';
@@ -155,6 +156,8 @@ case 'about':
         return <LDAManager user={currentUser} onReady={handleFeatureReady} />;
       case 'personalized-email':
         return <PersonalizedEmail user={currentUser} accessToken={accessToken} onReady={handleFeatureReady} />;
+      case 'report-generation':
+        return <ReportGeneration user={currentUser} onReady={handleFeatureReady} />;
       case 'student-view':
       default:
         // Pass user and ready-handler to StudentView

--- a/react/src/components/reportGeneration/ReportGeneration.jsx
+++ b/react/src/components/reportGeneration/ReportGeneration.jsx
@@ -1,0 +1,38 @@
+/*
+ * Timestamp: 2026-03-17 00:00:00
+ * Description: Report Generation side panel component.
+ * Opens when the "Generate Report" ribbon button is clicked.
+ * Currently displays the header only - further steps will add report generation functionality.
+ */
+
+import React, { useEffect } from 'react';
+import { FileSpreadsheet } from 'lucide-react';
+
+export default function ReportGeneration({ user, onReady }) {
+  useEffect(() => {
+    // Signal to App.jsx that this component is ready
+    if (onReady) {
+      onReady();
+    }
+  }, [onReady]);
+
+  return (
+    <div className="flex flex-col h-screen bg-gray-50">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-4 bg-white border-b border-gray-200 shadow-sm">
+        <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-blue-100 text-blue-600">
+          <FileSpreadsheet size={20} />
+        </div>
+        <div>
+          <h1 className="text-lg font-semibold text-gray-900">Generate Report</h1>
+          <p className="text-xs text-gray-500">Create and export retention reports</p>
+        </div>
+      </div>
+
+      {/* Content area - placeholder for future steps */}
+      <div className="flex-1 flex items-center justify-center p-6">
+        <p className="text-sm text-gray-400">Report generation options coming soon.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This PR introduces a new Report Generation feature to the Student Retention Add-in, adding a new side panel that opens when users click the "Generate Report" ribbon button.

## Key Changes
- **New Component**: Created `ReportGeneration.jsx` component that serves as the main UI for the report generation feature
  - Displays a header with icon, title, and description
  - Includes a placeholder content area for future report generation functionality
  - Implements the `onReady` callback pattern consistent with other features
  
- **Manifest Configuration**: Updated `manifest.xml` to register the new feature
  - Added "Generate Report" button control to the ribbon
  - Configured button with label, tooltip, and icon references
  - Registered the task pane with ID `ReportGenerationPane` and URL routing
  - Added image resources for button icons (16x16, 32x32, 80x80)
  - Added localized strings for button label and tooltip

- **App Router Integration**: Updated `App.jsx` to handle the new route
  - Imported the `ReportGeneration` component
  - Added case handler for `'report-generation'` page parameter
  - Passes user context and ready callback to the component

## Implementation Details
- The component follows the established pattern used by other features (PersonalizedEmail, LDAManager)
- Uses Tailwind CSS for styling with a clean, professional layout
- Leverages the `FileSpreadsheet` icon from lucide-react for visual consistency
- The feature is currently a shell with placeholder text; actual report generation logic can be added incrementally
- All UI strings are properly localized through the manifest resource definitions

https://claude.ai/code/session_01N7F13kAszjGGqkuyEnLpip