### PR TITLE
build: add manifest.prod.xml pointing at the Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,15 @@ flows by sideloading the manifest into Excel.
 
 ## Deploy
 
-The add-in's HTML/JS is hosted at `https://vsblanco.github.io/Student-Retention-Add-in/`.
-Pushing the built `react/dist/` contents along with `commands/`, `shared/`,
-and `assets/` updates the live add-in. The manifest URLs (in `manifest.xml`)
-all point at that base URL.
+Two environments, two manifests, both served from the same repo:
+
+- **Dev — GitHub Pages.** `https://vsblanco.github.io/Student-Retention-Add-in/`
+  served from this repo's `gh-pages` setup. Use `manifest.xml` to sideload.
+- **Prod — Vercel.** `https://student-retention-kit.vercel.app/` auto-deployed
+  from `main` via Vercel's GitHub integration (config in `vercel.json`). Use
+  `manifest.prod.xml` to sideload.
+
+Both manifests serve identical add-in functionality; only the host URLs
+differ. The Azure AD App ID URI (`api://vsblanco.github.io/...`) is a
+logical identifier registered in Azure AD and stays the same in both
+manifests — it does NOT need to match the hosting domain.

--- a/manifest.prod.xml
+++ b/manifest.prod.xml
@@ -1,0 +1,262 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
+  <Id>a8b1e479-1b3d-4e9e-9a1c-2f8e1c8b4a0e</Id>
+  <Version>2.1.0.2</Version>
+  <ProviderName>Victor Blanco</ProviderName>
+  <DefaultLocale>en-US</DefaultLocale>
+  <DisplayName DefaultValue="Student Retention Add-in"/>
+  <Description DefaultValue="An add-in for tracking student retention tasks."/>
+  
+  <IconUrl DefaultValue="https://student-retention-kit.vercel.app/assets/icon-32.png"/>
+  
+  <SupportUrl DefaultValue="https://github.com/vsblanco/Student-Retention-Add-in"/>
+  <AppDomains>
+    <AppDomain>https://student-retention-kit.vercel.app</AppDomain>
+  </AppDomains>
+  <Hosts>
+    <Host Name="Workbook"/>
+  </Hosts>
+  <DefaultSettings>
+    <SourceLocation DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html"/>
+    <RequestedWidth>450</RequestedWidth>
+  </DefaultSettings>
+  <Permissions>ReadWriteDocument</Permissions>
+
+  <!-- Requirements for autoload functionality -->
+  <Requirements>
+    <Sets DefaultMinVersion="1.1">
+      <Set Name="SharedRuntime" MinVersion="1.1"/>
+    </Sets>
+  </Requirements>
+
+  <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
+    <Hosts>
+      <Host xsi:type="Workbook">
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+
+          <FunctionFile resid="Commands.Url"/>
+
+          <!-- Runtimes for shared runtime and autoload -->
+          <Runtimes>
+            <Runtime resid="Commands.Url" lifetime="long" />
+          </Runtimes>
+
+          <!-- LaunchEvent: Load add-in automatically when document opens -->
+          <ExtensionPoint xsi:type="LaunchEvent">
+            <LaunchEvents>
+              <LaunchEvent Type="OnNewDocument" FunctionName="onDocumentOpen" />
+              <LaunchEvent Type="OnDocumentOpened" FunctionName="onDocumentOpen" />
+            </LaunchEvents>
+            <SourceLocation resid="Commands.Url" />
+          </ExtensionPoint>
+
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <CustomTab id="Victor.RetentionTab">
+              <Label resid="RetentionTab.Label"/>
+              <Group id="SystemGroup">
+                <Label resid="SystemGroup.Label"/>
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16"/>
+                  <bt:Image size="32" resid="Icon.32x32"/>
+                  <bt:Image size="80" resid="Icon.80x80"/>
+                </Icon>
+                <Control xsi:type="Button" id="SettingsButton">
+                  <Label resid="SettingsButton.Label"/>
+                  <Supertip>
+                    <Title resid="SettingsButton.Label"/>
+                    <Description resid="SettingsButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="SettingsIcon.16x16"/>
+                    <bt:Image size="32" resid="SettingsIcon.32x32"/>
+                    <bt:Image size="80" resid="SettingsIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>SettingsPane</TaskpaneId>
+                    <SourceLocation resid="Settings.Url"/>
+                  </Action>
+                </Control>
+              </Group>
+              <Group id="ReportGroup">
+                <Label resid="ReportGroup.Label"/>
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16"/>
+                  <bt:Image size="32" resid="Icon.32x32"/>
+                  <bt:Image size="80" resid="Icon.80x80"/>
+                </Icon>
+                <Control xsi:type="Button" id="GenerateReportButton">
+                  <Label resid="GenerateReportButton.Label"/>
+                  <Supertip>
+                    <Title resid="GenerateReportButton.Label"/>
+                    <Description resid="GenerateReportButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="ReportIcon.16x16"/>
+                    <bt:Image size="32" resid="ReportIcon.32x32"/>
+                    <bt:Image size="80" resid="ReportIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ReportGenerationPane</TaskpaneId>
+                    <SourceLocation resid="ReportGeneration.Url"/>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="CreateLdaButton">
+                  <Label resid="CreateLdaButton.Label"/>
+                  <Supertip>
+                    <Title resid="CreateLdaButton.Label"/>
+                    <Description resid="CreateLdaButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="CreateLdaIcon.16x16"/>
+                    <bt:Image size="32" resid="CreateLdaIcon.32x32"/>
+                    <bt:Image size="80" resid="CreateLdaIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>CreateLdaPane</TaskpaneId>
+                    <SourceLocation resid="CreateLdaDialog.Url"/>
+                  </Action>
+                </Control>
+                 <Control xsi:type="Button" id="PersonalizedEmailButton">
+                  <Label resid="PersonalizedEmailButton.Label"/>
+                  <Supertip>
+                    <Title resid="PersonalizedEmailButton.Label"/>
+                    <Description resid="PersonalizedEmailButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="EmailIcon.16x16"/>
+                    <bt:Image size="32" resid="EmailIcon.32x32"/>
+                    <bt:Image size="80" resid="EmailIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>PersonalizedEmailPane</TaskpaneId>
+                    <SourceLocation resid="PersonalizedEmail.Url"/>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="CallQueueButton">
+                  <Label resid="CallQueueButton.Label"/>
+                  <Supertip>
+                    <Title resid="CallQueueButton.Label"/>
+                    <Description resid="CallQueueButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="CallIcon.16x16"/>
+                    <bt:Image size="32" resid="CallIcon.32x32"/>
+                    <bt:Image size="80" resid="CallIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>sendToCallQueue</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+              <Group id="StudentViewGroup">
+                <Label resid="StudentViewGroup.Label"/>
+                <Icon>
+                  <bt:Image size="16" resid="DetailsIcon.16x16"/>
+                  <bt:Image size="32" resid="DetailsIcon.32x32"/>
+                  <bt:Image size="80" resid="DetailsIcon.80x80"/>
+                </Icon>
+                <Control xsi:type="Button" id="StudentViewButton">
+                  <Label resid="StudentViewButton.Label"/>
+                  <Supertip>
+                    <Title resid="StudentViewButton.Label"/>
+                    <Description resid="StudentViewButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="DetailsIcon.16x16"/>
+                    <bt:Image size="32" resid="DetailsIcon.32x32"/>
+                    <bt:Image size="80" resid="DetailsIcon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>StudentViewPane</TaskpaneId>
+                    <SourceLocation resid="StudentView.Url"/>
+                  </Action>
+                </Control>
+              </Group>
+            </CustomTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+    </Hosts>
+    <Resources>
+      <bt:Images>
+        <bt:Image id="Icon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-16.png"/>
+        <bt:Image id="Icon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-32.png"/>
+        <bt:Image id="Icon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-80.png"/>
+        <bt:Image id="CreateLdaIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/create-lda-icon.png"/>
+        <bt:Image id="CreateLdaIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/create-lda-icon.png"/>
+        <bt:Image id="CreateLdaIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/create-lda-icon.png"/>
+        <bt:Image id="DetailsIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/details-icon.png"/>
+        <bt:Image id="DetailsIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/details-icon.png"/>
+        <bt:Image id="DetailsIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/details-icon.png"/>
+        <bt:Image id="SettingsIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/settings-icon.png"/>
+        <bt:Image id="SettingsIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/settings-icon.png"/>
+        <bt:Image id="SettingsIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/settings-icon.png"/>
+        <bt:Image id="EmailIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/email-icon.png"/>
+        <bt:Image id="EmailIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/email-icon.png"/>
+        <bt:Image id="EmailIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/email-icon.png"/>
+        <bt:Image id="CallIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/call-icon.png"/>
+        <bt:Image id="CallIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/call-icon.png"/>
+        <bt:Image id="CallIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/call-icon.png"/>
+        <bt:Image id="ReportIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-16.png"/>
+        <bt:Image id="ReportIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-32.png"/>
+        <bt:Image id="ReportIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-80.png"/>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
+        <bt:Url id="Commands.Url" DefaultValue="https://student-retention-kit.vercel.app/commands/commands.html"/>
+        <bt:Url id="StudentView.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=student-view"/>
+        <bt:Url id="Settings.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=settings"/>
+        <bt:Url id="CreateLdaDialog.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=create-lda"/>
+        <bt:Url id="WelcomeDialog.Url" DefaultValue="https://student-retention-kit.vercel.app/welcome-dialog.html"/>
+        <bt:Url id="PersonalizedEmail.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=personalized-email"/>
+        <bt:Url id="ReportGeneration.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=report-generation"/>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="GetStarted.Title" DefaultValue="Get started with the Retention Add-in!"/>
+        <bt:String id="RetentionTab.Label" DefaultValue="Retention"/>
+        <bt:String id="SystemGroup.Label" DefaultValue="System"/>
+        <bt:String id="ReportGroup.Label" DefaultValue="Report"/>
+        <bt:String id="StudentViewGroup.Label" DefaultValue="Student View"/>
+        <bt:String id="StudentViewButton.Label" DefaultValue="Student View"/>
+        <bt:String id="CreateLdaButton.Label" DefaultValue="Create LDA"/>
+        <bt:String id="SettingsButton.Label" DefaultValue="Settings"/>
+        <bt:String id="PersonalizedEmailButton.Label" DefaultValue="Send Emails"/>
+        <bt:String id="CallQueueButton.Label" DefaultValue="Call"/>
+        <bt:String id="GenerateReportButton.Label" DefaultValue="Generate Report"/>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="GetStarted.Description" DefaultValue="Your add-in loaded successfully. Go to the 'Retention' tab to get started."/>
+        <bt:String id="StudentViewButton.Tooltip" DefaultValue="Click to show the student details pane."/>
+        <bt:String id="CreateLdaButton.Tooltip" DefaultValue="Creates a new LDA sheet for the current date."/>
+        <bt:String id="SettingsButton.Tooltip" DefaultValue="Click to configure add-in settings."/>
+        <bt:String id="PersonalizedEmailButton.Tooltip" DefaultValue="Opens a task pane to send a personalized email to the selected student."/>
+        <bt:String id="CallQueueButton.Tooltip" DefaultValue="Sends selected student(s) to the Chrome Extension call queue."/>
+        <bt:String id="GenerateReportButton.Tooltip" DefaultValue="Opens the report generation panel to create and export retention reports."/>
+      </bt:LongStrings>
+    </Resources>
+
+    <!--
+      WebApplicationInfo: Required for Microsoft SSO (Single Sign-On)
+      IMPORTANT: Must be the last child element of VersionOverrides
+
+      Configuration:
+      - Id: Azure AD Application (Client) ID
+      - Resource: Application ID URI (must match Azure AD configuration)
+      - Scopes: Required OAuth scopes (openid and profile are mandatory for SSO)
+    -->
+    <WebApplicationInfo>
+      <Id>71f37f39-a330-413a-be61-0baa5ce03ea3</Id>
+      <Resource>api://vsblanco.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3</Resource>
+      <Scopes>
+        <Scope>openid</Scope>
+        <Scope>profile</Scope>
+        <Scope>api://vsblanco.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user</Scope>
+      </Scopes>
+    </WebApplicationInfo>
+  </VersionOverrides>
+</OfficeApp>


### PR DESCRIPTION
Adds a parallel manifest for the Vercel-hosted prod deploy at https://student-retention-kit.vercel.app/. Generated by substituting the GitHub Pages URL pattern in manifest.xml; 31 URL changes.

Deliberately NOT changed:
- SupportUrl  → still https://github.com/vsblanco/Student-Retention-Add-in (it's the source repo link, not a hosting URL)
- Resource    → still api://vsblanco.github.io/<guid>
                (Azure AD App ID URI is a logical identifier registered
                in Azure AD, not the hosting domain — switching the
                hosting URL doesn't require changing it. Note: if SSO
                fails after sideloading manifest.prod.xml, the Azure AD
                app registration's Redirect URIs / SPA Origins list
                may need https://student-retention-kit.vercel.app
                added — that's an Azure portal config change, not a
                manifest one.)

README.md updated to document the dev (GitHub Pages → manifest.xml) vs prod (Vercel → manifest.prod.xml) split.

https://claude.ai/code/session_017Hit97hgf3Z3eaeKR7DzT7