### PR TITLE
build(vercel): override Vite base to /react/dist/ for the Vercel deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd react && npm install && npm run build",
+  "buildCommand": "cd react && npm install && npm run build -- --base=/react/dist/",
   "outputDirectory": ".",
   "framework": null,
   "cleanUrls": false,


### PR DESCRIPTION
The first Vercel deploy 404'd on JS/CSS assets:
  GET .../Student-Retention-Add-in/react/dist/assets/index-CAgdPoeQ.js
      net::ERR_ABORTED 404

Cause: react/config/vite.config.js hard-codes
  base: '/Student-Retention-Add-in/react/dist/'
which is correct for GitHub Pages (where the repo is served at /Student-Retention-Add-in/), but on Vercel there's no repo-name path segment — the same files live at /react/dist/.

Fix: pass --base=/react/dist/ to vite build via the npm script forward syntax. The Vercel buildCommand becomes:
  cd react && npm install && npm run build -- --base=/react/dist/

Vite's --base CLI flag overrides the config-file value at build time, so the committed react/dist/ (GitHub Pages-flavored) stays untouched. Vercel produces its own dist with the correct base during deploy.

Verified locally: with --base=/react/dist/, dist/index.html emits
  <script src="/react/dist/assets/index-...js">
  <link href="/react/dist/assets/index-...css">

https://claude.ai/code/session_017Hit97hgf3Z3eaeKR7DzT7