### PR TITLE
fix(manifest.prod): point WebApplicationInfo at the Vercel host

### DIFF
--- a/manifest.prod.xml
+++ b/manifest.prod.xml
@@ -251,11 +251,11 @@
     -->
     <WebApplicationInfo>
       <Id>71f37f39-a330-413a-be61-0baa5ce03ea3</Id>
-      <Resource>api://vsblanco.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3</Resource>
+      <Resource>api://student-retention-kit.vercel.app/71f37f39-a330-413a-be61-0baa5ce03ea3</Resource>
       <Scopes>
         <Scope>openid</Scope>
         <Scope>profile</Scope>
-        <Scope>api://vsblanco.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user</Scope>
+        <Scope>api://student-retention-kit.vercel.app/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user</Scope>
       </Scopes>
     </WebApplicationInfo>
   </VersionOverrides>


### PR DESCRIPTION
SSO at https://student-retention-kit.vercel.app/ failed with:
  SSO Error: Error 13004: Invalid resource Url specified in the manifest

Office's SSO validates that the WebApplicationInfo Resource URL's hostname matches the add-in's hosting domain. The previous prod manifest carried the GitHub Pages App ID URI:
  api://vsblanco.github.io/71f37f39-...

Office saw the mismatch with student-retention-kit.vercel.app and rejected. Update Resource and Scope to use the Vercel host instead:
  api://student-retention-kit.vercel.app/71f37f39-...

Required Azure AD changes (NOT in this commit — done separately in the Azure portal):
- Add api://student-retention-kit.vercel.app/<client-id> as an additional Application ID URI on app 71f37f39-...
- Add the Vercel hosting URL(s) as redirect URIs (SPA or Web platform) on the same app

The existing api://vsblanco.github.io/<client-id> URI is left in place so the GitHub Pages dev manifest keeps working.

https://claude.ai/code/session_017Hit97hgf3Z3eaeKR7DzT7