### PR TITLE
Remove report generation feature from add-in manifest

### DIFF
--- a/manifest.staging.xml
+++ b/manifest.staging.xml
@@ -89,22 +89,6 @@
                   <bt:Image size="32" resid="Icon.32x32"/>
                   <bt:Image size="80" resid="Icon.80x80"/>
                 </Icon>
-                <Control xsi:type="Button" id="GenerateReportButton">
-                  <Label resid="GenerateReportButton.Label"/>
-                  <Supertip>
-                    <Title resid="GenerateReportButton.Label"/>
-                    <Description resid="GenerateReportButton.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="ReportIcon.16x16"/>
-                    <bt:Image size="32" resid="ReportIcon.32x32"/>
-                    <bt:Image size="80" resid="ReportIcon.80x80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <TaskpaneId>ReportGenerationPane</TaskpaneId>
-                    <SourceLocation resid="ReportGeneration.Url"/>
-                  </Action>
-                </Control>
                 <Control xsi:type="Button" id="CreateLdaButton">
                   <Label resid="CreateLdaButton.Label"/>
                   <Supertip>
@@ -202,9 +186,6 @@
         <bt:Image id="CallIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/call-icon.png"/>
         <bt:Image id="CallIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/call-icon.png"/>
         <bt:Image id="CallIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/call-icon.png"/>
-        <bt:Image id="ReportIcon.16x16" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-16.png"/>
-        <bt:Image id="ReportIcon.32x32" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-32.png"/>
-        <bt:Image id="ReportIcon.80x80" DefaultValue="https://student-retention-kit.vercel.app/assets/icon-80.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
@@ -214,7 +195,6 @@
         <bt:Url id="CreateLdaDialog.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=create-lda"/>
         <bt:Url id="WelcomeDialog.Url" DefaultValue="https://student-retention-kit.vercel.app/welcome-dialog.html"/>
         <bt:Url id="PersonalizedEmail.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=personalized-email"/>
-        <bt:Url id="ReportGeneration.Url" DefaultValue="https://student-retention-kit.vercel.app/react/dist/index.html?page=report-generation"/>
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with the Retention Add-in!"/>
@@ -227,7 +207,6 @@
         <bt:String id="SettingsButton.Label" DefaultValue="Settings"/>
         <bt:String id="PersonalizedEmailButton.Label" DefaultValue="Send Emails"/>
         <bt:String id="CallQueueButton.Label" DefaultValue="Call"/>
-        <bt:String id="GenerateReportButton.Label" DefaultValue="Generate Report"/>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="Your add-in loaded successfully. Go to the 'Retention' tab to get started."/>
@@ -236,7 +215,6 @@
         <bt:String id="SettingsButton.Tooltip" DefaultValue="Click to configure add-in settings."/>
         <bt:String id="PersonalizedEmailButton.Tooltip" DefaultValue="Opens a task pane to send a personalized email to the selected student."/>
         <bt:String id="CallQueueButton.Tooltip" DefaultValue="Sends selected student(s) to the Chrome Extension call queue."/>
-        <bt:String id="GenerateReportButton.Tooltip" DefaultValue="Opens the report generation panel to create and export retention reports."/>
       </bt:LongStrings>
     </Resources>
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -89,22 +89,6 @@
                   <bt:Image size="32" resid="Icon.32x32"/>
                   <bt:Image size="80" resid="Icon.80x80"/>
                 </Icon>
-                <Control xsi:type="Button" id="GenerateReportButton">
-                  <Label resid="GenerateReportButton.Label"/>
-                  <Supertip>
-                    <Title resid="GenerateReportButton.Label"/>
-                    <Description resid="GenerateReportButton.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="ReportIcon.16x16"/>
-                    <bt:Image size="32" resid="ReportIcon.32x32"/>
-                    <bt:Image size="80" resid="ReportIcon.80x80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <TaskpaneId>ReportGenerationPane</TaskpaneId>
-                    <SourceLocation resid="ReportGeneration.Url"/>
-                  </Action>
-                </Control>
                 <Control xsi:type="Button" id="CreateLdaButton">
                   <Label resid="CreateLdaButton.Label"/>
                   <Supertip>
@@ -202,9 +186,6 @@
         <bt:Image id="CallIcon.16x16" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
         <bt:Image id="CallIcon.32x32" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
         <bt:Image id="CallIcon.80x80" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
-        <bt:Image id="ReportIcon.16x16" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/icon-16.png"/>
-        <bt:Image id="ReportIcon.32x32" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/icon-32.png"/>
-        <bt:Image id="ReportIcon.80x80" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/assets/icon-80.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
@@ -214,7 +195,6 @@
         <bt:Url id="CreateLdaDialog.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/react/dist/index.html?page=create-lda"/>
         <bt:Url id="WelcomeDialog.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/welcome-dialog.html"/>
         <bt:Url id="PersonalizedEmail.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/react/dist/index.html?page=personalized-email"/>
-        <bt:Url id="ReportGeneration.Url" DefaultValue="https://vsblanco.github.io/Student-Retention-Add-in/react/dist/index.html?page=report-generation"/>
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with the Retention Add-in!"/>
@@ -227,7 +207,6 @@
         <bt:String id="SettingsButton.Label" DefaultValue="Settings"/>
         <bt:String id="PersonalizedEmailButton.Label" DefaultValue="Send Emails"/>
         <bt:String id="CallQueueButton.Label" DefaultValue="Call"/>
-        <bt:String id="GenerateReportButton.Label" DefaultValue="Generate Report"/>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="Your add-in loaded successfully. Go to the 'Retention' tab to get started."/>
@@ -236,7 +215,6 @@
         <bt:String id="SettingsButton.Tooltip" DefaultValue="Click to configure add-in settings."/>
         <bt:String id="PersonalizedEmailButton.Tooltip" DefaultValue="Opens a task pane to send a personalized email to the selected student."/>
         <bt:String id="CallQueueButton.Tooltip" DefaultValue="Sends selected student(s) to the Chrome Extension call queue."/>
-        <bt:String id="GenerateReportButton.Tooltip" DefaultValue="Opens the report generation panel to create and export retention reports."/>
       </bt:LongStrings>
     </Resources>
 


### PR DESCRIPTION
## Summary
This PR removes the report generation feature from the Student Retention Add-in by deleting all related UI controls, resource definitions, and configuration entries from both manifest files.

## Key Changes
- **Removed UI Control**: Deleted the `GenerateReportButton` control definition that opened the report generation task pane
- **Removed Resource Definitions**: Deleted all icon resource definitions for the report button (16x16, 32x32, and 80x80 sizes)
- **Removed URL Configuration**: Deleted the `ReportGeneration.Url` resource pointing to the report generation page
- **Removed Localization Strings**: Deleted button label and tooltip strings for the report generation feature
- **Applied to Both Manifests**: Changes made consistently to both `manifest.xml` and `manifest.staging.xml`

## Implementation Details
The removal is complete and clean, with no orphaned references remaining. All related resources (icons, URLs, and localization strings) have been removed alongside the button control definition.

https://claude.ai/code/session_01CGcXMcc5fci4Mgrj4ufcyy