### PR TITLE
feat(settings): custom parameters import/export + tidy toggle labels

### DIFF
--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -91,7 +91,7 @@ export const defaultWorkbookSettings = [
 	},
 	{
 		id: 'excludeDNCDefault',
-		label: 'Exclude DNC by default',
+		label: 'Exclude DNC',
 		type: 'boolean',
 		defaultValue: true,
 		section: 'Send Emails',
@@ -99,7 +99,7 @@ export const defaultWorkbookSettings = [
 	},
 	{
 		id: 'excludeFillColorDefault',
-		label: 'Exclude Outreach Color by default',
+		label: 'Exclude Outreach Color',
 		type: 'boolean',
 		defaultValue: true,
 		section: 'Send Emails',
@@ -107,7 +107,7 @@ export const defaultWorkbookSettings = [
 	},
 	{
 		id: 'excludeNoMissingAssignmentsDefault',
-		label: 'Exclude 0 Missing Assignments by default',
+		label: 'Exclude 0 Missing Assignments',
 		type: 'boolean',
 		defaultValue: true,
 		section: 'Send Emails',


### PR DESCRIPTION
## Summary
- Adds a Send Emails → **Custom Parameters** Configure entry that opens an import/export modal mirroring the existing email-template flow (export to JSON, import with name-conflict resolution, reads/writes `customEmailParameters` workbook setting).
- Removes the redundant "On"/"Off" text next to boolean toggles in Settings.
- Drops the trailing "by default" qualifier from the three Send Emails exclusion toggle labels.

## Test plan
- [ ] Open Settings → Workbook → Send Emails, click **Custom Parameters → Configure**
- [ ] Export tab lists existing custom parameters; downloaded JSON round-trips through Import
- [ ] Import tab flags same-name conflicts and honors per-row Overwrite + "Overwrite All Conflicts"
- [ ] Imported parameters appear in the Personalized Email parameter buttons
- [ ] Boolean toggles in Settings render without "On"/"Off" labels
- [ ] Send Emails toggle labels read **Exclude DNC**, **Exclude Outreach Color**, **Exclude 0 Missing Assignments**

https://claude.ai/code/session_01Y3ziw7Esa7vxQXfBTVFDi2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3ziw7Esa7vxQXfBTVFDi2)_