### PR TITLE
Use relative URL for missing masterlist dialog

### DIFF
--- a/commands/src/master-list-import.js
+++ b/commands/src/master-list-import.js
@@ -204,7 +204,10 @@ async function importMissingAssignments(studentsWithAssignments) {
  * @param {object} payload - The original import payload to retry after sheet creation.
  */
 function showMissingMasterListDialog(payload) {
-    const dialogUrl = 'https://vsblanco.github.io/Student-Retention-Add-in/commands/missing-masterlist-dialog.html';
+    // Resolve relative to the runtime page (commands.html) so the dialog works
+    // on both prod (vsblanco.github.io) and staging (Vercel) without needing a
+    // host-specific URL — both AppDomains lists allow same-origin URLs.
+    const dialogUrl = new URL('missing-masterlist-dialog.html', window.location.href).href;
 
     Office.context.ui.displayDialogAsync(
         dialogUrl,


### PR DESCRIPTION
## Summary
Changed the missing masterlist dialog URL from a hardcoded absolute URL to a relative URL resolved against the current page location. This enables the dialog to work across different deployment environments without requiring environment-specific configuration.

## Key Changes
- Replaced hardcoded `https://vsblanco.github.io/Student-Retention-Add-in/commands/missing-masterlist-dialog.html` with a relative URL resolved using `new URL('missing-masterlist-dialog.html', window.location.href).href`
- This allows the dialog to work on both production (vsblanco.github.io) and staging (Vercel) environments automatically

## Implementation Details
- The relative URL is resolved against `window.location.href` (the commands.html page), which ensures the dialog HTML file is loaded from the same origin as the parent page
- Both production and staging AppDomains lists already allow same-origin URLs, so no additional configuration changes are needed
- This approach eliminates the need to maintain environment-specific URLs in the codebase

https://claude.ai/code/session_01BrUb48Bwn4yJuZfdKoxX68