### PR TITLE
feat(create-lda): show status page when Master List sheet is missing

### DIFF
--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -6,8 +6,8 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Info, CheckCircle2, Circle, Loader2, ArrowLeft, AlertCircle, ChevronRight, Plus, Pencil, Trash2, X } from 'lucide-react';
-import { createLDA, detectCampuses, detectProgramVersions, predictAdvisorDistribution, checkMissingLDAColumns, addColumnsToMasterList } from './ldaProcessor';
+import { Info, CheckCircle2, Circle, Loader2, ArrowLeft, AlertCircle, ChevronRight, Plus, Pencil, Trash2, X, ClipboardList } from 'lucide-react';
+import { createLDA, detectCampuses, detectProgramVersions, predictAdvisorDistribution, checkMissingLDAColumns, addColumnsToMasterList, checkMasterListExists } from './ldaProcessor';
 
 // --- CONFIGURATION: Steps matching the processor logic ---
 const PROCESS_STEPS = [
@@ -67,6 +67,28 @@ export default function CreateLDAManager({ onReady } = {}) {
   // app-level loading state until the toggles reflect saved values.
   const [initialSettingsLoaded, setInitialSettingsLoaded] = useState(false);
 
+  // 'checking' until the Master List sheet check resolves; 'present' lets the
+  // normal settings UI render; 'missing' swaps to the status page.
+  const [masterListStatus, setMasterListStatus] = useState('checking');
+
+  // Probe for the Master List sheet on mount. Without it there's nothing for
+  // the LDA processor to read, so the status page replaces the settings form.
+  // Importing data is the chrome extension's job, so this page is informational
+  // only — no "create master list" button.
+  useEffect(() => {
+    let isMounted = true;
+    checkMasterListExists()
+      .then(exists => {
+        if (!isMounted) return;
+        setMasterListStatus(exists ? 'present' : 'missing');
+      })
+      .catch(() => {
+        // Match the helper's fail-open behavior: don't block on a check failure.
+        if (isMounted) setMasterListStatus('present');
+      });
+    return () => { isMounted = false; };
+  }, []);
+
   // Load workbook settings on mount
   useEffect(() => {
     let isMounted = true;
@@ -119,13 +141,14 @@ export default function CreateLDAManager({ onReady } = {}) {
     };
   }, []);
 
-  // Signal ready only after the initial settings load completes so the parent
-  // loading screen stays up until toggles/badges reflect saved values.
+  // Signal ready only after both the initial settings load and the Master List
+  // check resolve, so the parent loading screen stays up until we know which
+  // view to render (status page vs. settings form).
   useEffect(() => {
-    if (initialSettingsLoaded && onReady) {
+    if (initialSettingsLoaded && masterListStatus !== 'checking' && onReady) {
       onReady();
     }
-  }, [initialSettingsLoaded, onReady]);
+  }, [initialSettingsLoaded, masterListStatus, onReady]);
 
   // Detect campuses when campus mode is toggled on
   useEffect(() => {
@@ -276,15 +299,19 @@ export default function CreateLDAManager({ onReady } = {}) {
     setIsMultiCampus(false);
   };
 
+  if (masterListStatus === 'missing') {
+    return <MissingMasterListStatus />;
+  }
+
   return (
     <div className="w-full max-w-2xl mx-auto bg-white rounded-2xl shadow-xl shadow-slate-200/60 border border-white overflow-hidden p-6 transition-all duration-300 min-h-[400px]">
-      
+
       {/* Header Area */}
       <div className="mb-6 flex items-center justify-between">
         <div>
             <h2 className={`text-2xl font-bold tracking-tight ${view === 'error' ? 'text-red-600' : 'text-slate-800'}`}>
-              {view === 'settings' ? 'Create LDA' : 
-               view === 'done' ? 'Complete' : 
+              {view === 'settings' ? 'Create LDA' :
+               view === 'done' ? 'Complete' :
                view === 'error' ? 'Error' :
                'Processing...'}
             </h2>
@@ -577,6 +604,31 @@ export default function CreateLDAManager({ onReady } = {}) {
 }
 
 // --- Sub-Components ---
+
+function MissingMasterListStatus() {
+  return (
+    <div className="w-full max-w-2xl mx-auto bg-white rounded-2xl shadow-xl shadow-slate-200/60 border border-white overflow-hidden p-6 min-h-[400px] flex items-center justify-center">
+      <div className="text-center max-w-sm animate-in fade-in slide-in-from-bottom-2 duration-500">
+        <div className="w-16 h-16 mx-auto mb-5 rounded-2xl bg-amber-50 border border-amber-100 flex items-center justify-center">
+          <ClipboardList className="w-8 h-8 text-amber-500" strokeWidth={1.75} />
+        </div>
+        <h2 className="text-xl font-bold tracking-tight text-slate-800 mb-2">
+          Missing Master List Sheet
+        </h2>
+        <p className="text-sm text-slate-500 leading-relaxed mb-4">
+          Create LDA reads from a <strong className="text-slate-700">Master List</strong> sheet
+          in this workbook, and one wasn't found. Without it there's no student
+          data to build the report from.
+        </p>
+        <div className="text-left text-xs text-slate-500 leading-relaxed bg-slate-50/80 border border-slate-100 rounded-xl px-4 py-3">
+          Use the <strong className="text-slate-700">Student Retention Kit</strong> Chrome
+          extension to send your roster into Excel, then reopen
+          <strong className="text-slate-700"> Create LDA</strong> to continue.
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function LDASettings({ settings, onSettingChange, settingsView, setSettingsView }) {
 

--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -1857,6 +1857,30 @@ async function writeTable(context, sheet, startRow, tableName, outputColumns, pr
 }
 
 /**
+ * Checks whether the Master List sheet exists in the active workbook.
+ * Used by LDAManager to short-circuit to a "missing master list" status
+ * page before showing the settings form, since LDA cannot be generated
+ * without a Master List.
+ * @returns {Promise<boolean>} True if the Master List sheet is present.
+ */
+export async function checkMasterListExists() {
+    try {
+        let exists = false;
+        await Excel.run(async (context) => {
+            const sheets = context.workbook.worksheets;
+            sheets.load("items/name");
+            await context.sync();
+            exists = sheets.items.some(s => s.name === SHEET_NAMES.MASTER_LIST);
+        });
+        return exists;
+    } catch (e) {
+        console.warn('checkMasterListExists failed, assuming present:', e);
+        // Fail open: don't trap users behind the status page if the check itself errors.
+        return true;
+    }
+}
+
+/**
  * Checks if key LDA columns (Outreach, Assigned) are missing from the Master List headers.
  * Uses the same space-insensitive matching as the main LDA processor.
  * @returns {Promise<{outreach: boolean, assigned: boolean}>} Object indicating which columns are missing.


### PR DESCRIPTION
## Summary
Add an informational "Missing Master List Sheet" status page to the Create LDA pane. When the pane mounts, it probes the active workbook for the Master List sheet and — if absent — replaces the settings form with a small status page explaining the situation.

No "create master list" button: importing rosters into Excel is the chrome extension's job, so the page just routes the user there.

## Changes
- `ldaProcessor.js` — new `checkMasterListExists()` export that lists worksheets and returns whether `Master List` is present. Fails open so a transient `Excel.run` error doesn't trap users on the status page.
- `LDAManager.jsx` — runs the probe on mount, blocks the `onReady` signal until the probe (and the existing settings load) resolves, and renders a new `MissingMasterListStatus` component when the sheet is missing. Reuses the existing card styling for visual consistency with the rest of the pane.

## Test plan
- [ ] Sideload the staging manifest into a workbook **with** a "Master List" sheet → Create LDA shows the normal settings form
- [ ] Sideload into a workbook **without** a "Master List" sheet → Create LDA shows the status page (clipboard icon, "Missing Master List Sheet", description)
- [ ] Verify there's no "Create" button on the status page
- [ ] Trigger an import via the chrome extension to add the sheet, reopen Create LDA → settings form loads as normal
- [ ] `cd react && npm test` (48 tests pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrUb48Bwn4yJuZfdKoxX68)_