### PR TITLE
feat(settings): Workbook Users page, Student History Create button, history download greying

### DIFF
--- a/react/src/App.jsx
+++ b/react/src/App.jsx
@@ -111,13 +111,32 @@ function App() {
 
   // Register the signed-in user in workbook settings once per session, in the
   // background. Office.context.document.settings may not be ready on first
-  // mount, so wait for Office.onReady before upserting. The helper itself
-  // dedupes by name, so calling it on every currentUser change is safe.
+  // mount, so wait for Office.onReady before upserting. Pull email from the
+  // SSO_USER_INFO cache that SSO.jsx writes during login; fall back to the
+  // bare name if it isn't available (e.g. guest mode). The helper dedupes
+  // (email-first, then name), so calling it on every currentUser change is safe.
   useEffect(() => {
     if (!currentUser) return;
     if (typeof window === 'undefined' || !window.Office || !Office.onReady) return;
+
+    let userInfo = { name: currentUser };
+    try {
+      const cached = localStorage.getItem('SSO_USER_INFO');
+      if (cached) {
+        const parsed = JSON.parse(cached);
+        if (parsed && typeof parsed === 'object') {
+          userInfo = {
+            name: parsed.name || currentUser,
+            email: typeof parsed.email === 'string' ? parsed.email : undefined,
+          };
+        }
+      }
+    } catch (e) {
+      console.warn('App: failed to parse SSO_USER_INFO for workbook user registration', e);
+    }
+
     Office.onReady(() => {
-      registerWorkbookUser(currentUser).catch(err => {
+      registerWorkbookUser(userInfo).catch(err => {
         console.warn('App: failed to register workbook user', err);
       });
     });

--- a/react/src/App.jsx
+++ b/react/src/App.jsx
@@ -8,6 +8,7 @@ import PersonalizedEmail from './components/personalizedEmail/PersonalizedEmail.
 import ReportGeneration from './components/reportGeneration/ReportGeneration.jsx';
 import Welcome from './components/welcomeScreen/Welcome.jsx'; // Import the Welcome component
 import chromeExtensionService from '../../shared/chromeExtensionService.js';
+import { registerWorkbookUser } from './services/workbookUsers.js';
 import { ToastContainer, Slide } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -107,6 +108,20 @@ function App() {
     // Mark as seen so it doesn't appear again
     localStorage.setItem('SRK_HAS_SEEN_WELCOME', 'true');
   };
+
+  // Register the signed-in user in workbook settings once per session, in the
+  // background. Office.context.document.settings may not be ready on first
+  // mount, so wait for Office.onReady before upserting. The helper itself
+  // dedupes by name, so calling it on every currentUser change is safe.
+  useEffect(() => {
+    if (!currentUser) return;
+    if (typeof window === 'undefined' || !window.Office || !Office.onReady) return;
+    Office.onReady(() => {
+      registerWorkbookUser(currentUser).catch(err => {
+        console.warn('App: failed to register workbook user', err);
+      });
+    });
+  }, [currentUser]);
 
   // --- CHROME EXTENSION MASTER RELAY ---
   // App.jsx manages the Chrome extension connection for all child components

--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -621,8 +621,8 @@ function MissingMasterListStatus() {
           data to build the report from.
         </p>
         <div className="text-left text-xs text-slate-500 leading-relaxed bg-slate-50/80 border border-slate-100 rounded-xl px-4 py-3">
-          Use the <strong className="text-slate-700">Student Retention Kit</strong> Chrome
-          extension to send your roster into Excel, then reopen
+          Use the Student Retention Kit <strong className="text-slate-700">Chrome
+          extension</strong> to send your roster into Excel, then reopen
           <strong className="text-slate-700"> Create LDA</strong> to continue.
         </div>
       </div>

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -144,6 +144,14 @@ export const defaultWorkbookSettings = [
 		defaultValue: null,
 		section: 'Student History',
 		description: 'Download the Student History sheet as a CSV file.'
+	},
+	{
+		id: 'workbookUsers',
+		label: 'Registered Users',
+		type: 'userslist',
+		defaultValue: null,
+		section: 'Users',
+		description: 'Users on file who have opened this workbook with the Student Retention Kit.'
 	}
 ];
 
@@ -172,6 +180,14 @@ export const sectionIcons = {
 		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 			<path d="M12 8v4l3 3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
 			<circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.6"/>
+		</svg>
+	),
+	'Users': (
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+			<path d="M17 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+			<circle cx="10" cy="8" r="3.5" stroke="currentColor" strokeWidth="1.6"/>
+			<path d="M21 21v-2a4 4 0 0 0-3-3.87" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+			<path d="M16.5 4.13a3.5 3.5 0 0 1 0 6.74" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
 		</svg>
 	)
 };

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -130,6 +130,14 @@ export const defaultWorkbookSettings = [
 		description: 'Import or export saved custom parameters as JSON.'
 	},
 	{
+		id: 'createHistorySheet',
+		label: 'Create Sheet',
+		type: 'action',
+		defaultValue: null,
+		section: 'Student History',
+		description: 'Create the Student History sheet with the standard column headers.'
+	},
+	{
 		id: 'downloadHistoryCsv',
 		label: 'Download Copy',
 		type: 'action',

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -632,18 +632,26 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 
 							if (setting.type === 'action') {
 								const isDownloading = setting.id === 'downloadHistoryCsv' && downloadingCsv;
+								// historyCommentCount is null both before the workbook summary loads and
+								// when the History sheet doesn't exist — either way, there's nothing to
+								// download yet, so disable the button.
+								const noHistorySheet = setting.id === 'downloadHistoryCsv' && historyCommentCount == null;
+								const isDisabled = isDownloading || noHistorySheet;
 								return (
 									<button
 										onClick={() => {
+											if (isDisabled) return;
 											if (setting.id === 'downloadHistoryCsv') downloadHistoryCsv();
 										}}
-										disabled={isDownloading}
+										disabled={isDisabled}
+										title={noHistorySheet ? `No "${HISTORY_SHEET}" sheet found — nothing to download` : undefined}
 										style={{
 											padding: '6px 10px',
 											borderRadius: 6,
-											background: isDownloading ? '#e5e7eb' : '#f3f4f6',
+											background: isDisabled ? '#e5e7eb' : '#f3f4f6',
 											border: '1px solid #e6e7eb',
-											cursor: isDownloading ? 'not-allowed' : 'pointer',
+											cursor: isDisabled ? 'not-allowed' : 'pointer',
+											color: noHistorySheet ? '#9ca3af' : undefined,
 											display: 'inline-flex',
 											alignItems: 'center',
 											gap: 6,

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -85,10 +85,10 @@ function UsersList() {
 				<ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 6 }}>
 					{sorted.map((u, i) => (
 						<li
-							key={`${u.name}-${u.dateJoined || i}`}
+							key={`${u.email || u.name}-${u.dateJoined || i}`}
 							style={{
 								display: 'grid',
-								gridTemplateColumns: '24px 1fr auto',
+								gridTemplateColumns: '28px 1fr auto',
 								alignItems: 'center',
 								gap: 10,
 								padding: '8px 12px',
@@ -98,15 +98,25 @@ function UsersList() {
 							}}
 						>
 							<div style={{
-								width: 24, height: 24, borderRadius: '50%',
+								width: 28, height: 28, borderRadius: '50%',
 								background: '#eef2ff', color: '#4338ca',
 								display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-								fontSize: 11, fontWeight: 700,
+								fontSize: 12, fontWeight: 700,
 							}}>
-								{(u.name || '?').slice(0, 1).toUpperCase()}
+								{(u.name || u.email || '?').slice(0, 1).toUpperCase()}
 							</div>
-							<div style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 13, fontWeight: 500 }}>
-								{u.name || 'Unknown'}
+							<div style={{ minWidth: 0, display: 'grid', gap: 1 }}>
+								<div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 13, fontWeight: 500 }}>
+									{u.name || 'Unknown'}
+								</div>
+								{u.email && (
+									<div
+										style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 11, color: '#6b7280' }}
+										title={u.email}
+									>
+										{u.email}
+									</div>
+								)}
 							</div>
 							<div style={{ fontSize: 11, color: '#6b7280', whiteSpace: 'nowrap' }} title={u.dateJoined ? new Date(u.dateJoined).toLocaleString() : undefined}>
 								Joined {formatJoinDate(u.dateJoined) || '—'}

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -11,6 +11,7 @@ import LicenseChecker from '../utility/LicenseChecker'; // <-- License checker (
 import UserInfoDisplay from '../utility/UserInfoDisplay'; // <-- User info from token (no API needed)
 import About from '../about/About'; // <-- ADDED: Import About component for Help tab
 import { HISTORY_SHEET, MASTER_LIST_SHEET } from '../../../../shared/constants.js';
+import { getWorkbookUsers } from '../../services/workbookUsers.js';
 
 const SUMMARY_BRAND = '#145F82';
 
@@ -20,6 +21,102 @@ function formatBytes(bytes) {
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+// Format an ISO timestamp as a short, readable join date.
+function formatJoinDate(iso) {
+	if (!iso) return '';
+	const d = new Date(iso);
+	if (isNaN(d.getTime())) return '';
+	return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+// Renders the workbook's registered-users roster on the Users sub-page.
+// Reads directly from document settings (not the parent Settings state) so a
+// fresh registration written by App.jsx still shows up if it lands while this
+// component is mounted, and re-reads on Office's SettingsChanged event.
+function UsersList() {
+	const [users, setUsers] = useState(() => getWorkbookUsers());
+
+	useEffect(() => {
+		const refresh = () => setUsers(getWorkbookUsers());
+		refresh();
+
+		const settings = (typeof window !== 'undefined' && window.Office && Office.context && Office.context.document)
+			? Office.context.document.settings
+			: null;
+		if (!settings || typeof settings.addHandlerAsync !== 'function') return;
+
+		const handler = () => refresh();
+		settings.addHandlerAsync(Office.EventType.SettingsChanged, handler);
+		return () => {
+			try { settings.removeHandlerAsync(Office.EventType.SettingsChanged, handler); } catch { /* ignore */ }
+		};
+	}, []);
+
+	// Newest joins first so a user can spot themselves quickly after registering.
+	const sorted = [...users].sort((a, b) => {
+		const aTime = a && a.dateJoined ? Date.parse(a.dateJoined) : 0;
+		const bTime = b && b.dateJoined ? Date.parse(b.dateJoined) : 0;
+		return bTime - aTime;
+	});
+
+	return (
+		<div style={{ display: 'grid', gap: 8, width: '100%' }}>
+			<div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', padding: '0 2px' }}>
+				<div style={{ fontSize: 14, fontWeight: 600 }}>Registered Users</div>
+				<div style={{ fontSize: 12, color: '#6b7280' }}>
+					{sorted.length} {sorted.length === 1 ? 'user' : 'users'}
+				</div>
+			</div>
+			{sorted.length === 0 ? (
+				<div style={{
+					padding: '12px 14px',
+					border: '1px dashed #e5e7eb',
+					borderRadius: 8,
+					background: '#fff',
+					color: '#6b7280',
+					fontSize: 13,
+					textAlign: 'center',
+				}}>
+					No users registered yet. Users are added automatically when they open this workbook with the Student Retention Kit signed in.
+				</div>
+			) : (
+				<ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 6 }}>
+					{sorted.map((u, i) => (
+						<li
+							key={`${u.name}-${u.dateJoined || i}`}
+							style={{
+								display: 'grid',
+								gridTemplateColumns: '24px 1fr auto',
+								alignItems: 'center',
+								gap: 10,
+								padding: '8px 12px',
+								background: '#fff',
+								border: '1px solid #e5e7eb',
+								borderRadius: 8,
+							}}
+						>
+							<div style={{
+								width: 24, height: 24, borderRadius: '50%',
+								background: '#eef2ff', color: '#4338ca',
+								display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+								fontSize: 11, fontWeight: 700,
+							}}>
+								{(u.name || '?').slice(0, 1).toUpperCase()}
+							</div>
+							<div style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 13, fontWeight: 500 }}>
+								{u.name || 'Unknown'}
+							</div>
+							<div style={{ fontSize: 11, color: '#6b7280', whiteSpace: 'nowrap' }} title={u.dateJoined ? new Date(u.dateJoined).toLocaleString() : undefined}>
+								Joined {formatJoinDate(u.dateJoined) || '—'}
+							</div>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
 }
 
 function SummaryCard({ icon, title, value, hint, accent = SUMMARY_BRAND }) {
@@ -518,6 +615,10 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 		const renderRow = setting => {
 			const cur = state[setting.id];
 			const inputId = `${idPrefix}${setting.id}`;
+			// Custom full-width row for the workbook user roster.
+			if (setting.type === 'userslist') {
+				return <UsersList key={setting.id} />;
+			}
 			return (
 				<div key={setting.id} style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center', gap: 8, width: '100%', boxSizing: 'border-box' }}>
 					{/* label area: stays in the left column and truncates if too long */}

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -117,6 +117,14 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 	// Download CSV state
 	const [downloadingCsv, setDownloadingCsv] = useState(false);
 
+	// Create Student History sheet state
+	const [creatingHistorySheet, setCreatingHistorySheet] = useState(false);
+
+	// Default headers for a freshly-created Student History sheet. Each name is
+	// a canonical alias from shared/columnAliases.js so the existing add/edit/
+	// delete-comment flows resolve them via canonicalHeaderMap.
+	const HISTORY_SHEET_HEADERS = ['SyStudentId', 'Student', 'Comment', 'Timestamp', 'Created By', 'Tag', 'Comment ID'];
+
 	// master list headers read from the active workbook (populated when columns modal opens)
 	const [masterListHeaders, setMasterListHeaders] = useState(null);
 
@@ -286,6 +294,42 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 			alert(err.message || 'Failed to download Student History');
 		} finally {
 			setDownloadingCsv(false);
+		}
+	};
+
+	// Create the "Student History" sheet with the default header row.
+	// Headers come from shared/columnAliases.js — see HISTORY_SHEET_HEADERS above.
+	const createHistorySheet = async () => {
+		if (creatingHistorySheet) return;
+		setCreatingHistorySheet(true);
+		try {
+			if (typeof window === 'undefined' || !window.Excel || !Excel.run) {
+				throw new Error('Excel API not available');
+			}
+			await Excel.run(async (context) => {
+				const sheets = context.workbook.worksheets;
+				const existing = sheets.getItemOrNullObject(HISTORY_SHEET);
+				await context.sync();
+				if (!existing.isNullObject) {
+					// Concurrent create raced us — bail without touching the existing sheet.
+					return;
+				}
+				const sheet = sheets.add(HISTORY_SHEET);
+				const headerRange = sheet.getRangeByIndexes(0, 0, 1, HISTORY_SHEET_HEADERS.length);
+				headerRange.values = [HISTORY_SHEET_HEADERS];
+				headerRange.format.font.bold = true;
+				sheet.getUsedRange().format.autofitColumns();
+				await context.sync();
+			});
+			// Optimistically reflect the new (header-only) sheet in the summary so the
+			// Create button greys out and the Download button enables without a refresh.
+			setHistoryCommentCount(0);
+			setSheetCount(prev => (typeof prev === 'number' ? prev + 1 : prev));
+		} catch (err) {
+			console.error('Failed to create Student History sheet:', err);
+			alert(err.message || 'Failed to create Student History sheet');
+		} finally {
+			setCreatingHistorySheet(false);
 		}
 	};
 
@@ -632,26 +676,37 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 
 							if (setting.type === 'action') {
 								const isDownloading = setting.id === 'downloadHistoryCsv' && downloadingCsv;
+								const isCreating = setting.id === 'createHistorySheet' && creatingHistorySheet;
 								// historyCommentCount is null both before the workbook summary loads and
 								// when the History sheet doesn't exist — either way, there's nothing to
 								// download yet, so disable the button.
 								const noHistorySheet = setting.id === 'downloadHistoryCsv' && historyCommentCount == null;
-								const isDisabled = isDownloading || noHistorySheet;
+								// Inverse for Create: greyed out when the sheet already exists, or while
+								// the workbook summary is still resolving so we don't race a duplicate.
+								const historySheetExists = setting.id === 'createHistorySheet' && (historyCommentCount != null || summaryLoading);
+								const isDisabled = isDownloading || isCreating || noHistorySheet || historySheetExists;
+								const isCreate = setting.id === 'createHistorySheet';
+								const greyedReason = noHistorySheet
+									? `No "${HISTORY_SHEET}" sheet found — nothing to download`
+									: (historySheetExists && historyCommentCount != null
+										? `"${HISTORY_SHEET}" sheet already exists`
+										: undefined);
 								return (
 									<button
 										onClick={() => {
 											if (isDisabled) return;
 											if (setting.id === 'downloadHistoryCsv') downloadHistoryCsv();
+											else if (setting.id === 'createHistorySheet') createHistorySheet();
 										}}
 										disabled={isDisabled}
-										title={noHistorySheet ? `No "${HISTORY_SHEET}" sheet found — nothing to download` : undefined}
+										title={greyedReason}
 										style={{
 											padding: '6px 10px',
 											borderRadius: 6,
 											background: isDisabled ? '#e5e7eb' : '#f3f4f6',
 											border: '1px solid #e6e7eb',
 											cursor: isDisabled ? 'not-allowed' : 'pointer',
-											color: noHistorySheet ? '#9ca3af' : undefined,
+											color: (noHistorySheet || historySheetExists) ? '#9ca3af' : undefined,
 											display: 'inline-flex',
 											alignItems: 'center',
 											gap: 6,
@@ -659,13 +714,23 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 										}}
 										aria-label={setting.label}
 									>
-										{/* download icon */}
-										<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-											<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-											<polyline points="7 10 12 15 17 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-											<line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-										</svg>
-										{isDownloading ? 'Downloading...' : 'Download'}
+										{isCreate ? (
+											/* plus icon */
+											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+												<line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+												<line x1="5" y1="12" x2="19" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+											</svg>
+										) : (
+											/* download icon */
+											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+												<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+												<polyline points="7 10 12 15 17 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+												<line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+											</svg>
+										)}
+										{isCreate
+											? (isCreating ? 'Creating...' : 'Create')
+											: (isDownloading ? 'Downloading...' : 'Download')}
 									</button>
 								);
 							}

--- a/react/src/services/workbookUsers.js
+++ b/react/src/services/workbookUsers.js
@@ -4,14 +4,16 @@
  * Tracks which Student Retention Kit users have opened this workbook.
  *
  * On SSO login (or auto-login from a cached SSO_USER), App.jsx calls
- * `registerWorkbookUser(username)` once per session. The user is upserted
- * into the workbook's `users` array under the existing `workbookSettings`
- * document setting, with a `dateJoined` ISO timestamp on first sight.
+ * `registerWorkbookUser({ name, email })` once per session. The user is
+ * upserted into the workbook's `users` array under the existing
+ * `workbookSettings` document setting, with a `dateJoined` ISO timestamp
+ * on first sight.
  *
- * Existing entries are left alone so the original join date is preserved
- * even if the same user reopens the workbook later. The list is surfaced
- * in Settings → Workbook → Users and can be used for future automation
- * (e.g. routing, distribution lists).
+ * Dedupe priority is email (case-insensitive), falling back to name.
+ * Existing entries preserve their original dateJoined; if a newer login
+ * provides an email that was previously missing, the record is enriched
+ * in place. The list is surfaced in Settings → Workbook → Users and can
+ * be used for future automation (e.g. routing, distribution lists).
  */
 
 const DOC_KEY = 'workbookSettings';
@@ -56,7 +58,7 @@ function writeWorkbookSettings(mapping) {
 
 /**
  * Returns the list of registered users (always an array; empty if missing).
- * @returns {Array<{name: string, dateJoined: string}>}
+ * @returns {Array<{name: string, email?: string, dateJoined: string}>}
  */
 export function getWorkbookUsers() {
     const settings = readWorkbookSettings();
@@ -67,34 +69,61 @@ export function getWorkbookUsers() {
 
 /**
  * Upserts the given user into the workbook's users list. If the user is
- * already registered, this is a no-op (preserves the original dateJoined).
+ * already registered, the existing record is preserved (original dateJoined
+ * stays intact); if the new info adds an email that was previously missing,
+ * the record is enriched in place.
+ *
  * Safe to call repeatedly — intended to run once per session in the background.
- * @param {string} username - SSO username (display name).
- * @returns {Promise<boolean>} True if a new user was added.
+ * @param {{name: string, email?: string} | string} userInfo - User to register.
+ *   Pass a string for the legacy "name only" form.
+ * @returns {Promise<boolean>} True if any change was written.
  */
-export async function registerWorkbookUser(username) {
-    if (!username || typeof username !== 'string') return false;
-    const trimmed = username.trim();
-    if (!trimmed) return false;
+export async function registerWorkbookUser(userInfo) {
+    const input = typeof userInfo === 'string' ? { name: userInfo } : (userInfo || {});
+    const name = typeof input.name === 'string' ? input.name.trim() : '';
+    const email = typeof input.email === 'string' ? input.email.trim() : '';
+    if (!name) return false;
     if (!isOfficeReady()) return false;
 
     const settings = readWorkbookSettings();
     if (!settings) return false;
 
     const users = Array.isArray(settings[USERS_KEY]) ? settings[USERS_KEY] : [];
-    const exists = users.some(u => u && typeof u.name === 'string' && u.name.toLowerCase() === trimmed.toLowerCase());
-    if (exists) return false;
 
-    const next = {
-        ...settings,
-        [USERS_KEY]: [
-            ...users,
-            { name: trimmed, dateJoined: new Date().toISOString() },
-        ],
-    };
+    // Email is the more reliable identifier (names can collide / change), so
+    // try it first and fall back to a name match for legacy entries.
+    const lcEmail = email.toLowerCase();
+    const lcName = name.toLowerCase();
+    let matchIdx = -1;
+    if (lcEmail) {
+        matchIdx = users.findIndex(u => u && typeof u.email === 'string' && u.email.toLowerCase() === lcEmail);
+    }
+    if (matchIdx === -1) {
+        matchIdx = users.findIndex(u => u && typeof u.name === 'string' && u.name.toLowerCase() === lcName);
+    }
+
+    let nextUsers;
+    if (matchIdx === -1) {
+        const record = { name, dateJoined: new Date().toISOString() };
+        if (email) record.email = email;
+        nextUsers = [...users, record];
+    } else {
+        const existing = users[matchIdx];
+        const merged = { ...existing };
+        // Back-fill missing fields without overwriting set values.
+        if (!merged.name && name) merged.name = name;
+        if (!merged.email && email) merged.email = email;
+        if (merged.name === existing.name && merged.email === existing.email) {
+            return false; // already up-to-date — skip the saveAsync round-trip
+        }
+        nextUsers = users.map((u, i) => (i === matchIdx ? merged : u));
+    }
+
+    const next = { ...settings, [USERS_KEY]: nextUsers };
     const ok = await writeWorkbookSettings(next);
     if (ok) {
-        console.log(`workbookUsers: registered "${trimmed}" in workbook settings`);
+        const action = matchIdx === -1 ? 'registered' : 'enriched';
+        console.log(`workbookUsers: ${action} "${name}"${email ? ` <${email}>` : ''} in workbook settings`);
     }
     return ok;
 }

--- a/react/src/services/workbookUsers.js
+++ b/react/src/services/workbookUsers.js
@@ -1,0 +1,100 @@
+/*
+ * workbookUsers.js
+ *
+ * Tracks which Student Retention Kit users have opened this workbook.
+ *
+ * On SSO login (or auto-login from a cached SSO_USER), App.jsx calls
+ * `registerWorkbookUser(username)` once per session. The user is upserted
+ * into the workbook's `users` array under the existing `workbookSettings`
+ * document setting, with a `dateJoined` ISO timestamp on first sight.
+ *
+ * Existing entries are left alone so the original join date is preserved
+ * even if the same user reopens the workbook later. The list is surfaced
+ * in Settings → Workbook → Users and can be used for future automation
+ * (e.g. routing, distribution lists).
+ */
+
+const DOC_KEY = 'workbookSettings';
+const USERS_KEY = 'users';
+
+function isOfficeReady() {
+    return typeof window !== 'undefined'
+        && window.Office
+        && Office.context
+        && Office.context.document
+        && Office.context.document.settings;
+}
+
+function readWorkbookSettings() {
+    if (!isOfficeReady()) return null;
+    try {
+        return Office.context.document.settings.get(DOC_KEY) || {};
+    } catch (err) {
+        console.warn('workbookUsers: failed to read document settings', err);
+        return null;
+    }
+}
+
+function writeWorkbookSettings(mapping) {
+    if (!isOfficeReady()) return Promise.resolve(false);
+    return new Promise(resolve => {
+        try {
+            Office.context.document.settings.set(DOC_KEY, mapping);
+            Office.context.document.settings.saveAsync(result => {
+                const ok = result && result.status === Office.AsyncResultStatus.Succeeded;
+                if (!ok && result && result.error) {
+                    console.warn('workbookUsers: saveAsync failed', result.error);
+                }
+                resolve(!!ok);
+            });
+        } catch (err) {
+            console.warn('workbookUsers: failed to set document settings', err);
+            resolve(false);
+        }
+    });
+}
+
+/**
+ * Returns the list of registered users (always an array; empty if missing).
+ * @returns {Array<{name: string, dateJoined: string}>}
+ */
+export function getWorkbookUsers() {
+    const settings = readWorkbookSettings();
+    if (!settings) return [];
+    const users = settings[USERS_KEY];
+    return Array.isArray(users) ? users : [];
+}
+
+/**
+ * Upserts the given user into the workbook's users list. If the user is
+ * already registered, this is a no-op (preserves the original dateJoined).
+ * Safe to call repeatedly — intended to run once per session in the background.
+ * @param {string} username - SSO username (display name).
+ * @returns {Promise<boolean>} True if a new user was added.
+ */
+export async function registerWorkbookUser(username) {
+    if (!username || typeof username !== 'string') return false;
+    const trimmed = username.trim();
+    if (!trimmed) return false;
+    if (!isOfficeReady()) return false;
+
+    const settings = readWorkbookSettings();
+    if (!settings) return false;
+
+    const users = Array.isArray(settings[USERS_KEY]) ? settings[USERS_KEY] : [];
+    const exists = users.some(u => u && typeof u.name === 'string' && u.name.toLowerCase() === trimmed.toLowerCase());
+    if (exists) return false;
+
+    const next = {
+        ...settings,
+        [USERS_KEY]: [
+            ...users,
+            { name: trimmed, dateJoined: new Date().toISOString() },
+        ],
+    };
+    const ok = await writeWorkbookSettings(next);
+    if (ok) {
+        console.log(`workbookUsers: registered "${trimmed}" in workbook settings`);
+    }
+    return ok;
+}


### PR DESCRIPTION
## Summary
Follow-up changes to the Settings → Workbook tab plus a small wording fix on the Create LDA status page.

## Changes

### Settings → Workbook → Student History
- **Greyed-out Download** button when no `Student History` sheet exists (tooltip: `No "Student History" sheet found — nothing to download`).
- **New Create Sheet button** that creates the sheet with the seven canonical headers — `SyStudentId`, `Student`, `Comment`, `Timestamp`, `Created By`, `Tag`, `Comment ID` — bolded and autofitted. Greys out when the sheet already exists or while the workbook summary is still resolving (avoids racing a duplicate). Optimistically updates the local summary on success so both buttons immediately reflect the new state.

### Settings → Workbook → Users (new)
- New page that lists every Student Retention Kit user who has opened this workbook, sorted newest-first.
- Each row shows initial avatar, name, email (truncated, full value on hover), and "Joined Mon DD, YYYY".
- New `react/src/services/workbookUsers.js` service with `registerWorkbookUser({ name, email })` (email-first dedupe, name fallback) and `getWorkbookUsers()`. Existing entries preserve original `dateJoined`; emails missing on legacy records are back-filled in place.
- `App.jsx` reads `SSO_USER_INFO` from `localStorage` (already populated by `SSO.jsx` on login) and registers the user once per session in the background via `Office.onReady`.
- `UsersList` component reads document settings directly and subscribes to `Office.EventType.SettingsChanged`, so a registration that completes while Settings is mounted shows up live.

### LDA missing-master-list status page
- Bold "Chrome extension" instead of "Student Retention Kit" so the user's eye lands on the actionable noun.

## Test plan
- [ ] Sideload staging manifest in a workbook with no `Student History` sheet → Download button greyed out, Create Sheet button enabled. Click Create → sheet appears with the seven headers (bolded), Create greys out, Download enables.
- [ ] Sideload again with the sheet already present → Create button greyed out from the start.
- [ ] Open Settings → Workbook → Users → first time you sign in, your name appears with email and today's join date. Reopen → still showing original `dateJoined`.
- [ ] Have a second user open the same workbook (or simulate via cleared localStorage + new SSO) → both rows present, newest-first ordering.
- [ ] Open Create LDA without a Master List → status page shows the brief description with **Chrome extension** bolded.
- [ ] `cd react && npm test` (48 tests pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BrUb48Bwn4yJuZfdKoxX68)_