### PR TITLE
Separate ID and StudentNumber column aliases for clarity

### DIFF
--- a/react/src/components/studentView/StudentView.jsx
+++ b/react/src/components/studentView/StudentView.jsx
@@ -350,10 +350,10 @@ function StudentView({ onReady, user }) {
             const anyMatch = matches.some(m => m.match);
             return anyMatch;
           },
-          null,               
-          'Outreach',               
-          COLUMN_ALIASES,     
-          ['StudentName','ID'] 
+          null,
+          'Outreach',
+          COLUMN_ALIASES,
+          ['StudentName','ID','StudentNumber']
         );
       } catch (err) {
         console.error('Failed to register Excel cell-change handler:', err);

--- a/react/src/components/utility/ColumnMapping.jsx
+++ b/react/src/components/utility/ColumnMapping.jsx
@@ -38,11 +38,15 @@ export const Sheets = {
 // Matching is case- and whitespace-insensitive (handled by normalizeHeader
 // in /shared/excel-helpers.js).
 //
-// "ID" composes SyStudentId aliases first (preferred), then Student Number
-// as fallback.
+// SyStudentId (canonical "ID") and Student Number are intentionally
+// distinct concepts — Student Number is the legacy identifier kept for
+// backwards-compatible reads. Writes that use canonical "ID" resolve to
+// SyStudentId columns only; callers that need Student Number as a
+// fallback should look up canonical "StudentNumber" separately.
 export const COLUMN_ALIASES = {
   StudentName: STUDENT_NAME_ALIASES,
-  ID: [...STUDENT_ID_ALIASES, ...STUDENT_NUMBER_ALIASES],
+  ID: STUDENT_ID_ALIASES,
+  StudentNumber: STUDENT_NUMBER_ALIASES,
   Gender: GENDER_ALIASES,
   Phone: PRIMARY_PHONE_ALIASES,
   CreatedBy: CREATED_BY_ALIASES,
@@ -74,6 +78,7 @@ export const COLUMN_ALIASES_HISTORY = {
   comment: COMMENT_ALIASES,
   createdBy: CREATED_BY_ALIASES,
   tag: TAGS_ALIASES,
-  StudentID: [...STUDENT_ID_ALIASES, ...STUDENT_NUMBER_ALIASES],
+  StudentID: STUDENT_ID_ALIASES,
+  StudentNumber: STUDENT_NUMBER_ALIASES,
   commentID: COMMENT_ID_ALIASES,
 };

--- a/react/src/components/utility/EditStudentHistory.jsx
+++ b/react/src/components/utility/EditStudentHistory.jsx
@@ -8,6 +8,10 @@ import { Sheets } from './ColumnMapping';
 // StudentView, or the raw active-student state). Both the auto Outreach handler
 // and the manual NewComment flow must use this so comments end up keyed against
 // the same identity regardless of which path created them.
+//
+// Prefers SyStudentId (canonical `ID`) over Student Number — Student Number is
+// the legacy identifier and is only used as a fallback when no SyStudentId
+// column is present on the source sheet.
 export function resolveStudentIdentity(obj) {
   if (!obj || typeof obj !== 'object') {
     return { studentId: null, studentName: null };
@@ -15,6 +19,7 @@ export function resolveStudentIdentity(obj) {
   const studentId =
     obj.ID ?? obj.Id ?? obj.id ??
     obj.StudentID ?? obj.studentID ?? obj.studentId ??
+    obj.StudentNumber ?? obj.studentNumber ?? obj['Student Number'] ??
     null;
   const studentName =
     obj.Student ?? obj.StudentName ?? obj.studentName ??


### PR DESCRIPTION
## Summary
This PR clarifies the distinction between SyStudentId (canonical "ID") and Student Number (legacy identifier) by separating their column aliases and updating the resolution logic to prefer SyStudentId while maintaining backwards compatibility.

## Key Changes
- **ColumnMapping.jsx**: Split `ID` and `StudentNumber` into separate entries in `COLUMN_ALIASES` and `COLUMN_ALIASES_HISTORY` instead of combining them. `ID` now maps only to `STUDENT_ID_ALIASES`, while `StudentNumber` maps to `STUDENT_NUMBER_ALIASES`.
- **StudentView.jsx**: Updated the Excel cell-change handler registration to include `'StudentNumber'` in the monitored columns list alongside `'StudentName'` and `'ID'`.
- **EditStudentHistory.jsx**: Enhanced `resolveStudentIdentity()` to check Student Number variants (`obj.StudentNumber`, `obj.studentNumber`, `obj['Student Number']`) as fallback options after exhausting all SyStudentId variants, with updated documentation clarifying the preference hierarchy.

## Implementation Details
- The changes maintain backwards compatibility by still accepting Student Number values, but only as a fallback when no SyStudentId is present.
- Column alias separation makes the intent clearer: writes using canonical "ID" resolve only to SyStudentId columns; callers needing Student Number must explicitly reference the `StudentNumber` alias.
- Updated comments throughout explain that Student Number is a legacy identifier kept for backwards-compatible reads.

https://claude.ai/code/session_014ddSRNxsGVRFv1XaVZf4bL