### PR TITLE
fix(lda): detect SyStudentId for DNC and LDA-followup tag maps

### DIFF
--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -11,6 +11,7 @@
 import { getWorkbookSettings } from '../utility/getSettings';
 import { defaultColumns } from '../settings/DefaultSettings';
 import { MASTER_LIST_SHEET, HISTORY_SHEET, BATCH_SIZE } from '../../../../shared/constants.js';
+import { STUDENT_ID_ALIASES, STUDENT_NUMBER_ALIASES } from '../../../../shared/columnAliases.js';
 
 const SHEET_NAMES = {
     MASTER_LIST: MASTER_LIST_SHEET,
@@ -387,7 +388,15 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
             // --- Retrieve Key Indices ---
             const daysOutIdx = getColIndex('Days Out');
             const gradeIdx = getColIndex('Grade');
-            const studentIdIdx = getColIndex('Student Number');
+            // Prefer SyStudentId (the modern identifier); fall back to Student
+            // Number for legacy workbooks. Without this fallback the DNC and
+            // LDA-followup tag maps stay empty whenever the Master List uses
+            // SyStudentId instead of Student Number.
+            let studentIdIdx = -1;
+            for (const candidate of [...STUDENT_ID_ALIASES, ...STUDENT_NUMBER_ALIASES]) {
+                studentIdIdx = getColIndex(candidate);
+                if (studentIdIdx !== -1) break;
+            }
 
             // --- ProgramVersion index for advisor assignment ---
             const pvAliases = ['programversion', 'program', 'progversdescrip'];


### PR DESCRIPTION
## Summary
Follow-up to #277. The Outreach fix split `ID` and `StudentNumber` aliases, but the DNC/LDA-tag pipeline in `ldaProcessor.js` had the same root-cause bug: it hardcoded the Master List's student-id column to `'Student Number'`.

On workbooks that use SyStudentId (without a Student Number column), `getColIndex('Student Number')` returned `-1`, which:
- Short-circuited the `dncMap`/`ldaFollowUpMap` builders at `ldaProcessor.js:862` and `:1195` (they're guarded by `studentIdIdx !== -1`).
- Left `sId` undefined for every Master List row at `:954` and `:1298`, so even if the maps had been populated, no row would have matched.

Net effect: DNC strikethroughs on phone columns and LDA follow-up messages never fired for SyStudentId-only workbooks.

## Fix
Walk `STUDENT_ID_ALIASES` (SyStudentId, Student ID, ID) first, then `STUDENT_NUMBER_ALIASES` (Student Number, Student Identifier) as a fallback. Modern workbooks resolve to SyStudentId; legacy workbooks still find Student Number.

The History-sheet side of this code already collected every ID-like column from each row into `hIdIndices`, so the dncMap was correctly keyed under both SyStudentId and Student Number values — only the Master-List-side lookup needed the fix.

## Test plan
- [ ] On a workbook whose Master List has SyStudentID (no Student Number column) and a History row tagged `DNC - Phone` for that student, run Create LDA → confirm the Phone column is struck through.
- [ ] On a legacy workbook whose Master List has only Student Number, run Create LDA → confirm DNC strikethroughs still fire (fallback path).
- [ ] Same two workbooks with a future-dated `LDA 12/15/26` history tag → confirm the LDA-followup retention message appears.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ddSRNxsGVRFv1XaVZf4bL)_