### PR TITLE
Suppress heartbeat ping logs to keep console readable

### DIFF
--- a/commands/background-service.js
+++ b/commands/background-service.js
@@ -64,6 +64,12 @@ Office.onReady(() => {
 
     // Dispatch incoming extension events
     chromeExtensionService.addListener((event) => {
+        // Side panel heartbeat pings arrive every few seconds and are
+        // answered by setupPingResponseListener; nothing below handles
+        // them, so skip the per-event logging entirely.
+        if (event.type === "message" && event.data?.type === "SRK_PING" && event.data.heartbeat) {
+            return;
+        }
         console.log("Background: Chrome Extension event:", event);
 
         if (event.type === "installed") {

--- a/commands/src/chrome-extension-messaging.js
+++ b/commands/src/chrome-extension-messaging.js
@@ -19,13 +19,20 @@ import chromeExtensionService from '../../shared/chromeExtensionService.js';
  */
 export function setupPingResponseListener() {
     window.addEventListener("message", (event) => {
+        // Heartbeat pings from the extension side panel repeat every few
+        // seconds for as long as the panel is open; answer them silently
+        // so this console stays readable.
+        const isHeartbeatPing = !!(event.data && event.data.type === "SRK_PING" && event.data.heartbeat);
+
         // Log all incoming messages for debugging
-        if (event.data && event.data.type && event.data.type.startsWith('SRK_')) {
+        if (event.data && event.data.type && event.data.type.startsWith('SRK_') && !isHeartbeatPing) {
             console.log(`📨 Background Service: Received ${event.data.type} message:`, event.data);
         }
 
         if (event.data && event.data.type === "SRK_PING") {
-            console.log('🏓 Background Service: Received SRK_PING, sending pong...');
+            if (!isHeartbeatPing) {
+                console.log('🏓 Background Service: Received SRK_PING, sending pong...');
+            }
 
             // Send pong response back to extension
             window.postMessage({
@@ -34,7 +41,9 @@ export function setupPingResponseListener() {
                 source: "excel-addin-background"
             }, "*");
 
-            console.log('✅ Background Service: SRK_PONG sent to Chrome extension');
+            if (!isHeartbeatPing) {
+                console.log('✅ Background Service: SRK_PONG sent to Chrome extension');
+            }
         }
 
         if (event.data && event.data.type === "SRK_LINKS") {


### PR DESCRIPTION
## Summary
Filters out heartbeat ping messages from Chrome extension side panel logs to prevent console spam while maintaining visibility of meaningful messages.

## Changes
- **`commands/src/chrome-extension-messaging.js`**: Added detection for heartbeat pings (identified by `event.data.type === "SRK_PING"` with `heartbeat` flag) and suppressed their console logs while still responding with pong messages silently
  - Detects heartbeat pings early and skips logging for incoming message, pong response, and confirmation messages
  - Continues to respond to heartbeat pings normally (silent response)
  
- **`commands/background-service.js`**: Added early return for heartbeat ping events in the extension event listener to skip per-event logging entirely
  - Prevents heartbeat pings from being logged as generic Chrome Extension events

## Implementation Details
The side panel sends heartbeat pings every few seconds while open. These are answered automatically by `setupPingResponseListener` but were cluttering the console with repetitive logs. The fix identifies heartbeat pings by checking for a `heartbeat` property on the `SRK_PING` message type and suppresses logging for these messages only, while preserving full visibility of actual extension events and user-initiated pings.

https://claude.ai/code/session_01YFtZ2SN83p5PU52sP3DM8G