### PR TITLE
Answer scan filter settings requests from today's LDA sheet

### DIFF
--- a/commands/__tests__/scan-filter-derivation.test.js
+++ b/commands/__tests__/scan-filter-derivation.test.js
@@ -1,0 +1,128 @@
+/*
+ * Tests for the scan-filter derivation helpers (commands/src/scan-filter-derivation.js):
+ * resolving today's LDA sheet name and deriving the extension's scan-filter
+ * settings (minimum Days Out, failing list presence) from sheet values.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+    todaysLdaSheetBaseName,
+    pickTodaysLdaSheet,
+    deriveScanFilterFromGrid
+} from '../src/scan-filter-derivation.js';
+
+const JUNE_12 = new Date(2026, 5, 12);
+
+describe('todaysLdaSheetBaseName', () => {
+    it('formats without zero padding, matching ldaProcessor date mode', () => {
+        expect(todaysLdaSheetBaseName(JUNE_12)).toBe('LDA 6-12-2026');
+        expect(todaysLdaSheetBaseName(new Date(2026, 10, 3))).toBe('LDA 11-3-2026');
+    });
+});
+
+describe('pickTodaysLdaSheet', () => {
+    it('finds the exact base name', () => {
+        expect(pickTodaysLdaSheet(['Master List', 'LDA 6-12-2026'], JUNE_12)).toBe('LDA 6-12-2026');
+    });
+
+    it('finds zero-padded and slash date variants', () => {
+        expect(pickTodaysLdaSheet(['LDA 06-12-2026'], JUNE_12)).toBe('LDA 06-12-2026');
+        expect(pickTodaysLdaSheet(['LDA 6/12/2026'], JUNE_12)).toBe('LDA 6/12/2026');
+    });
+
+    it('prefers the highest "(n)" copy over the base sheet', () => {
+        const names = ['LDA 6-12-2026', 'LDA 6-12-2026 (2)', 'LDA 6-12-2026 (3)'];
+        expect(pickTodaysLdaSheet(names, JUNE_12)).toBe('LDA 6-12-2026 (3)');
+    });
+
+    it('returns null when only other days exist', () => {
+        expect(pickTodaysLdaSheet(['LDA 6-11-2026', 'Master List'], JUNE_12)).toBeNull();
+    });
+
+    it('does not match unrelated sheets with similar prefixes', () => {
+        expect(pickTodaysLdaSheet(['LDA 6-12-2026 backup', 'LDA 6-12-2026 (two)'], JUNE_12)).toBeNull();
+    });
+});
+
+describe('deriveScanFilterFromGrid', () => {
+    const HEADERS = ['Student Name', 'Grade', 'Days Out', 'Outreach'];
+    const FAILING_TITLE_ROW = ['Failing Students (Active)', '', '', ''];
+    const ATTENDANCE_TITLE_ROW = ['Low Attendance Students', '', '', ''];
+    const BLANK = ['', '', '', ''];
+
+    it('uses the minimum Days Out of the main table', () => {
+        const grid = [
+            HEADERS,
+            ['A', 80, 12, ''],
+            ['B', 70, 6, ''],
+            ['C', 90, 4, '']
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: '>=4', includeFailing: false });
+    });
+
+    it('detects the failing section and excludes it from the minimum', () => {
+        const grid = [
+            HEADERS,
+            ['A', 80, 9, ''],
+            ['B', 70, 5, ''],
+            BLANK, BLANK, BLANK,
+            FAILING_TITLE_ROW,
+            HEADERS,
+            ['F1', 40, 1, ''],
+            ['F2', 55, 0, '']
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: '>=5', includeFailing: true });
+    });
+
+    it('ignores the attendance section without flagging failing', () => {
+        const grid = [
+            HEADERS,
+            ['A', 80, 7, ''],
+            BLANK, BLANK, BLANK,
+            ATTENDANCE_TITLE_ROW,
+            HEADERS,
+            ['L1', 80, 2, '']
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: '>=7', includeFailing: false });
+    });
+
+    it('matches the Days Out header case- and space-insensitively', () => {
+        const grid = [
+            ['student name', 'GRADE', 'DAYSOUT', 'outreach'],
+            ['A', 80, 3, '']
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: '>=3', includeFailing: false });
+    });
+
+    it('floors fractional minimums for the extension filter parser', () => {
+        const grid = [
+            HEADERS,
+            ['A', 80, 4.5, '']
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: '>=4', includeFailing: false });
+    });
+
+    it('returns null daysOutFilter for a headers-only sheet', () => {
+        expect(deriveScanFilterFromGrid([HEADERS])).toEqual({ daysOutFilter: null, includeFailing: false });
+    });
+
+    it('returns null daysOutFilter when no Days Out column exists', () => {
+        const grid = [
+            ['Student Name', 'Grade'],
+            ['A', 80]
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: null, includeFailing: false });
+    });
+
+    it('skips non-numeric Days Out cells in the main table', () => {
+        const grid = [
+            HEADERS,
+            ['A', 80, 'n/a', ''],
+            ['B', 70, 6, '']
+        ];
+        expect(deriveScanFilterFromGrid(grid)).toEqual({ daysOutFilter: '>=6', includeFailing: false });
+    });
+
+    it('handles an empty grid', () => {
+        expect(deriveScanFilterFromGrid([])).toEqual({ daysOutFilter: null, includeFailing: false });
+    });
+});

--- a/commands/background-service.js
+++ b/commands/background-service.js
@@ -25,6 +25,7 @@ import {
     sendSheetListToExtension,
 } from './src/chrome-extension-messaging.js';
 import { startCommandPropertyPoller } from './src/power-automate-poller.js';
+import { sendScanFilterSettingsToExtension } from './src/scan-filter-settings.js';
 
 // Required for the Analytics ribbon button — manifest uses ShowTaskpane,
 // but Office still expects an associated function.
@@ -116,6 +117,11 @@ Office.onReady(() => {
             case 'SRK_REQUEST_SHEET_LIST':
                 console.log("Background: Received sheet list request from extension");
                 sendSheetListToExtension();
+                break;
+
+            case 'SRK_REQUEST_SCAN_FILTER_SETTINGS':
+                console.log("Background: Received scan filter settings request from extension");
+                sendScanFilterSettingsToExtension();
                 break;
         }
     });

--- a/commands/src/scan-filter-derivation.js
+++ b/commands/src/scan-filter-derivation.js
@@ -1,0 +1,117 @@
+/*
+ * scan-filter-derivation.js
+ *
+ * Pure helpers for deriving Chrome extension scan-filter settings from a
+ * day's LDA sheet. No Excel.run / chrome / window usage here so these can
+ * be unit tested directly (see __tests__/scan-filter-derivation.test.js).
+ *
+ * The LDA sheet layout these helpers understand is the one ldaProcessor.js
+ * (react taskpane) writes in 'date' mode:
+ *   - row 0: headers (includes a "Days Out" column)
+ *   - rows 1..n: the main LDA table, sorted by Days Out descending
+ *   - blank spacer rows
+ *   - optional bold title cell "Failing Students (Active)" in column 0,
+ *     followed by the failing table
+ *   - optional "Low Attendance Students" section in the same shape
+ */
+import { findColumnIndex, normalizeHeader, sheetNameDateVariants } from '../../shared/excel-helpers.js';
+import { CONSTANTS } from './constants.js';
+
+// Section titles ldaProcessor writes into column 0 (normalized forms)
+const FAILING_TITLE = normalizeHeader('Failing Students (Active)');
+const ATTENDANCE_TITLE = normalizeHeader('Low Attendance Students');
+
+/**
+ * Base name of today's LDA sheet, matching ldaProcessor's 'date' naming:
+ * "LDA M-D-YYYY" (no zero padding).
+ * @param {Date} [date] - Defaults to today
+ * @returns {string}
+ */
+export function todaysLdaSheetBaseName(date = new Date()) {
+    return `LDA ${date.getMonth() + 1}-${date.getDate()}-${date.getFullYear()}`;
+}
+
+/**
+ * Finds today's LDA sheet among the workbook's sheet names. Tolerates the
+ * zero-padded / slash date variants via sheetNameDateVariants, plus the
+ * " (2)", " (3)" suffixes ldaProcessor appends when the base name is taken
+ * — the highest counter (most recently created) wins.
+ *
+ * @param {string[]} sheetNames - All worksheet names in the workbook
+ * @param {Date} [date] - Defaults to today
+ * @returns {string|null} The sheet name to inspect, or null if none found
+ */
+export function pickTodaysLdaSheet(sheetNames, date = new Date()) {
+    const variants = sheetNameDateVariants(todaysLdaSheetBaseName(date));
+
+    let best = null;
+    let bestCounter = -1;
+    for (const name of sheetNames) {
+        for (const variant of variants) {
+            if (name === variant) {
+                // Base name (counter 0) loses to any "(n)" copy
+                if (bestCounter < 0) { best = name; bestCounter = 0; }
+            } else if (name.startsWith(`${variant} (`)) {
+                const match = name.slice(variant.length).match(/^ \((\d+)\)$/);
+                if (match) {
+                    const counter = parseInt(match[1], 10);
+                    if (counter > bestCounter) { best = name; bestCounter = counter; }
+                }
+            }
+        }
+    }
+    return best;
+}
+
+/**
+ * Derives scan-filter settings from an LDA sheet's used-range values.
+ *
+ * - daysOutFilter: ">=N" where N is the minimum numeric Days Out value in
+ *   the MAIN table only (the failing/attendance sections hold students
+ *   below the threshold and must not drag the minimum down). Null when the
+ *   main table has no numeric Days Out values (e.g. headers only).
+ * - includeFailing: whether a "Failing Students (Active)" section exists
+ *   anywhere on the sheet. ldaProcessor only writes that title when the
+ *   failing list was enabled AND produced rows.
+ *
+ * @param {Array<Array<*>>} values - 2D used-range values, headers in row 0
+ * @returns {{ daysOutFilter: string|null, includeFailing: boolean }}
+ */
+export function deriveScanFilterFromGrid(values) {
+    if (!Array.isArray(values) || values.length === 0) {
+        return { daysOutFilter: null, includeFailing: false };
+    }
+
+    const normalizedHeaders = values[0].map(normalizeHeader);
+    const daysOutIdx = findColumnIndex(normalizedHeaders, CONSTANTS.COLUMN_MAPPINGS.daysOut);
+
+    const isBlankRow = (row) => row.every(cell => cell === null || cell === undefined || String(cell).trim() === '');
+    const sectionTitleOf = (row) => {
+        const first = normalizeHeader(String(row[0] ?? ''));
+        return first === FAILING_TITLE || first === ATTENDANCE_TITLE ? first : null;
+    };
+
+    // Walk the main table: contiguous rows after the header, ending at the
+    // first blank row or section title.
+    let minDaysOut = null;
+    if (daysOutIdx !== -1) {
+        for (let r = 1; r < values.length; r++) {
+            const row = values[r];
+            if (isBlankRow(row) || sectionTitleOf(row)) break;
+            const value = row[daysOutIdx];
+            if (typeof value === 'number' && !isNaN(value)) {
+                minDaysOut = minDaysOut === null ? value : Math.min(minDaysOut, value);
+            }
+        }
+    }
+
+    // The failing section can sit anywhere below the main table.
+    const includeFailing = values.some(row => sectionTitleOf(row) === FAILING_TITLE);
+
+    return {
+        // Floor fractional values: the extension's filter parser only
+        // accepts integers, and >=floor(min) still includes the min row.
+        daysOutFilter: minDaysOut !== null ? `>=${Math.floor(minDaysOut)}` : null,
+        includeFailing
+    };
+}

--- a/commands/src/scan-filter-settings.js
+++ b/commands/src/scan-filter-settings.js
@@ -1,0 +1,58 @@
+/*
+ * scan-filter-settings.js
+ *
+ * Answers the Chrome extension's SRK_REQUEST_SCAN_FILTER_SETTINGS message
+ * (sent when the user presses Start on the submission checker). Inspects
+ * today's LDA sheet and replies with the scan-filter settings it implies:
+ * the minimum Days Out on the main table and whether a failing list was
+ * generated. When today's LDA sheet doesn't exist the reply says so and
+ * the extension makes no change.
+ */
+import chromeExtensionService from '../../shared/chromeExtensionService.js';
+import { pickTodaysLdaSheet, deriveScanFilterFromGrid } from './scan-filter-derivation.js';
+
+/**
+ * Reads today's LDA sheet and sends SRK_SCAN_FILTER_SETTINGS back to the
+ * Chrome extension. Always replies — ldaFound:false when there is no sheet
+ * for today — so the extension can report the outcome instead of waiting
+ * for its timeout.
+ * @returns {Promise<void>}
+ */
+export async function sendScanFilterSettingsToExtension() {
+    const reply = (data) => {
+        chromeExtensionService.sendMessage({
+            type: 'SRK_SCAN_FILTER_SETTINGS',
+            data: { ...data, timestamp: new Date().toISOString() }
+        });
+    };
+
+    try {
+        await Excel.run(async (context) => {
+            const sheets = context.workbook.worksheets;
+            sheets.load('items/name');
+            await context.sync();
+
+            const sheetName = pickTodaysLdaSheet(sheets.items.map(s => s.name));
+            if (!sheetName) {
+                console.log("ScanFilter: No LDA sheet for today — telling extension to keep its settings.");
+                reply({ ldaFound: false });
+                return;
+            }
+
+            const usedRange = sheets.getItem(sheetName).getUsedRange();
+            usedRange.load('values');
+            await context.sync();
+
+            const derived = deriveScanFilterFromGrid(usedRange.values);
+            console.log(`ScanFilter: Derived from "${sheetName}":`, derived);
+            reply({ ldaFound: true, sheetName, ...derived });
+        });
+    } catch (error) {
+        console.error('ScanFilter: Error deriving scan filter settings:', error);
+        if (typeof OfficeExtension !== 'undefined' && error instanceof OfficeExtension.Error) {
+            console.error('ScanFilter: Debug info:', JSON.stringify(error.debugInfo));
+        }
+        // Report as not found so the extension proceeds with its settings.
+        reply({ ldaFound: false, error: error.message });
+    }
+}


### PR DESCRIPTION
When the Chrome extension's submission checker starts, it now sends SRK_REQUEST_SCAN_FILTER_SETTINGS. The commands runtime resolves today's LDA sheet (date variants and "(n)" copies included, newest copy wins), derives the settings the sheet implies — ">=minimum Days Out" from the main table only, and includeFailing from the presence of the "Failing Students (Active)" section — and replies with SRK_SCAN_FILTER_SETTINGS. When there is no LDA sheet for today it replies ldaFound:false so the extension keeps its current settings.

Derivation is a pure module (scan-filter-derivation.js) with vitest coverage; the Excel.run reader and reply live in scan-filter-settings.js following the existing messaging-module pattern.

https://claude.ai/code/session_01YFtZ2SN83p5PU52sP3DM8G