### PR TITLE
Fix year-folder month comparison in History tab cleanup

### DIFF
--- a/react/src/components/studentView/Tabs/History.jsx
+++ b/react/src/components/studentView/Tabs/History.jsx
@@ -315,8 +315,11 @@ useEffect(() => {
          // Remove months that no longer exist
          Object.keys(mergedMonths).forEach(m => {
            const isCurrentYearMonth = sortedCurrentYearMonths.includes(m);
+           // Year-folder months are keyed by the composite `${year}-${month}`,
+           // so compare against that form (not the bare month) or they'd be
+           // dropped here and lose their collapsed-by-default state.
            const isYearMonth = sortedYears.some(year => {
-             return yearGroups[year] && Object.keys(yearGroups[year]).includes(m);
+             return yearGroups[year] && Object.keys(yearGroups[year]).some(month => `${year}-${month}` === m);
            });
            if (!isCurrentYearMonth && !isYearMonth) delete mergedMonths[m];
          });


### PR DESCRIPTION
## Summary
Fixed a bug in the History tab's month cleanup logic where year-folder months were being incorrectly dropped because the comparison was using bare month strings instead of the composite `${year}-${month}` keys used to store them.

## Changes
- Updated the `isYearMonth` check in the month removal loop to properly compare against the composite key format (`${year}-${month}`) instead of bare month strings
- Added clarifying comments explaining why year-folder months use composite keys and must be compared in that form to preserve their collapsed-by-default state

## Details
The bug occurred because `yearGroups[year]` stores months using composite keys like `"2024-01"`, but the comparison was checking if the bare month string (e.g., `"01"`) existed in that object's keys. This caused year-folder months to always fail the `isYearMonth` check and be deleted from `mergedMonths`, losing their UI state.

The fix changes the comparison from a simple `.includes(m)` to a `.some()` that constructs the expected composite key format before comparing, ensuring year-folder months are correctly identified and preserved.

https://claude.ai/code/session_01PmWu9x3ubmekLYG7grhhD3