### PR TITLE
Move Expanded DNC / Compact Column Width toggles to Settings taskpane

### DIFF
--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -178,24 +178,9 @@ export default function CreateLDAManager({ onReady } = {}) {
       // Persist advisorAssignment to workbook settings
       if (key === 'advisorAssignment') {
         saveAdvisorAssignmentToWorkbook(value);
-      } else if (key === 'expandedDNC' || key === 'compactColumnWidth') {
-        saveSettingToWorkbook(key, value);
       }
       return next;
     });
-  };
-
-  const saveSettingToWorkbook = (key, value) => {
-    try {
-      if (typeof window !== 'undefined' && window.Office && Office.context && Office.context.document && Office.context.document.settings) {
-        const wb = Office.context.document.settings.get('workbookSettings') || {};
-        wb[key] = value;
-        Office.context.document.settings.set('workbookSettings', wb);
-        Office.context.document.settings.saveAsync(() => {});
-      }
-    } catch (e) {
-      console.error('Failed to save setting:', key, e);
-    }
   };
 
   const saveAdvisorAssignmentToWorkbook = (advisorAssignment) => {
@@ -888,27 +873,6 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
         </div>
         <ChevronRight className="w-4 h-4 text-slate-400" />
       </button>
-
-      {/* Advanced section */}
-      <div className="pt-3 mt-1 border-t border-slate-100">
-        <span className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Advanced</span>
-      </div>
-
-      <ToggleRow
-        key="toggle-expanded-dnc"
-        label="Expanded DNC"
-        tooltip="Fill the Outreach column with the DNC comment text and who left it, instead of a flat 'Do not contact'. Off restores the original DNC behavior."
-        isOn={settings.expandedDNC}
-        onToggle={() => handleToggle('expandedDNC')}
-      />
-
-      <ToggleRow
-        key="toggle-compact-column-width"
-        label="Compact Column Width"
-        tooltip="Pin key columns (Outreach, ProgramVersion, etc.) to fixed widths and wrap the Outreach text. Off autosizes columns like before."
-        isOn={settings.compactColumnWidth}
-        onToggle={() => handleToggle('compactColumnWidth')}
-      />
     </div>
   );
 }

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -82,6 +82,22 @@ export const defaultWorkbookSettings = [
 		description: 'Whether to include the Do Not Contact students.'
 	},
 	{
+		id: 'expandedDNC',
+		label: 'Expanded DNC',
+		type: 'boolean',
+		defaultValue: false,
+		section: 'Create LDA',
+		description: 'Fill the Outreach column with the DNC comment text and who left it, instead of a flat "Do not contact". Off restores the original DNC behavior.'
+	},
+	{
+		id: 'compactColumnWidth',
+		label: 'Compact Column Width',
+		type: 'boolean',
+		defaultValue: true,
+		section: 'Create LDA',
+		description: 'Pin key columns (Outreach, ProgramVersion, etc.) to fixed widths and wrap the Outreach text. Off autosizes columns like before.'
+	},
+	{
 		id: 'powerAutomateUrl',
 		label: 'Power Automate',
 		type: 'powerautomate',


### PR DESCRIPTION
Place the two advanced toggles under the Settings taskpane's Create LDA section instead of on the Create LDA page. They persist to the same workbookSettings keys the LDA processor already reads, so behavior is unchanged; only the toggle location moved. LDAManager still loads the values to pass through to createLDA.