### PR TITLE
Make PDF receipt inclusion optional in Power Automate payloads

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -951,28 +951,30 @@ export default function PersonalizedEmail({ user, onReady }) {
             return;
         }
 
-        // Generate base64 PDF receipt to include in payload
-        const initiator = { name: user, email: userEmail };
-        const receiptBase64 = generatePdfReceipt(
-            payload.emails,
-            body,
-            initiator,
-            true // returnBase64
-        );
+        // Optionally include a base64 PDF receipt in the payload (off by default;
+        // controlled by the "Include Receipts" toggle in the Power Automate config)
+        let payloadToSend = payload;
+        if (powerAutomateConnection?.includeReceipt === true) {
+            const initiator = { name: user, email: userEmail };
+            const receiptBase64 = generatePdfReceipt(
+                payload.emails,
+                body,
+                initiator,
+                true // returnBase64
+            );
+            payloadToSend = {
+                ...payload,
+                receipt: receiptBase64 || ''
+            };
+        }
 
-        // Add receipt to payload
-        const payloadWithReceipt = {
-            ...payload,
-            receipt: receiptBase64 || ''
-        };
-
-        setLastSentPayload(payloadWithReceipt);
+        setLastSentPayload(payloadToSend);
 
         try {
             const response = await fetch(powerAutomateConnection.url, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payloadWithReceipt)
+                body: JSON.stringify(payloadToSend)
             });
             if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             await recordLastSent(payload.emails.length);
@@ -1098,23 +1100,27 @@ export default function PersonalizedEmail({ user, onReady }) {
 
         try {
             if (mode === 'powerautomate') {
-                const initiator = { name: user, email: userEmail };
-                const receiptBase64 = generatePdfReceipt(
-                    testPayload.emails,
-                    body,
-                    initiator,
-                    true // returnBase64
-                );
-
-                const testPayloadWithReceipt = {
-                    ...testPayload,
-                    receipt: receiptBase64 || ''
-                };
+                // Optionally include a base64 PDF receipt in the payload (off by default;
+                // controlled by the "Include Receipts" toggle in the Power Automate config)
+                let testPayloadToSend = testPayload;
+                if (powerAutomateConnection?.includeReceipt === true) {
+                    const initiator = { name: user, email: userEmail };
+                    const receiptBase64 = generatePdfReceipt(
+                        testPayload.emails,
+                        body,
+                        initiator,
+                        true // returnBase64
+                    );
+                    testPayloadToSend = {
+                        ...testPayload,
+                        receipt: receiptBase64 || ''
+                    };
+                }
 
                 const response = await fetch(powerAutomateConnection.url, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(testPayloadWithReceipt)
+                    body: JSON.stringify(testPayloadToSend)
                 });
 
                 if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);

--- a/react/src/components/settings/PowerAutomateConfigModal.jsx
+++ b/react/src/components/settings/PowerAutomateConfigModal.jsx
@@ -5,6 +5,7 @@ export default function PowerAutomateConfigModal({ isOpen, onClose }) {
     const [status, setStatus] = useState('');
     const [currentConnection, setCurrentConnection] = useState(null);
     const [enabled, setEnabled] = useState(true);
+    const [includeReceipt, setIncludeReceipt] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
 
     useEffect(() => {
@@ -28,11 +29,13 @@ export default function PowerAutomateConfigModal({ isOpen, onClose }) {
                 if (connection) {
                     setCurrentConnection(connection);
                     setEnabled(connection.enabled !== false);
+                    setIncludeReceipt(connection.includeReceipt === true);
                     setUrl(''); // Don't expose the URL for security
                     setStatus('Connection configured');
                 } else {
                     setCurrentConnection(null);
                     setEnabled(true);
+                    setIncludeReceipt(false);
                     setUrl('');
                     setStatus('No connection configured');
                 }
@@ -86,6 +89,38 @@ export default function PowerAutomateConfigModal({ isOpen, onClose }) {
         }
     };
 
+    const handleToggleIncludeReceipt = async (newIncludeReceipt) => {
+        if (!currentConnection) return;
+        setIncludeReceipt(newIncludeReceipt);
+
+        try {
+            await Excel.run(async (context) => {
+                const settings = context.workbook.settings;
+                const connectionsSetting = settings.getItemOrNullObject("connections");
+                connectionsSetting.load("value");
+                await context.sync();
+
+                const connections = connectionsSetting.value ? JSON.parse(connectionsSetting.value) : [];
+                const updated = connections.map(c =>
+                    (c.type === 'power-automate' && c.name === 'Send Personalized Email')
+                        ? { ...c, includeReceipt: newIncludeReceipt }
+                        : c
+                );
+                settings.add("connections", JSON.stringify(updated));
+                await context.sync();
+
+                setCurrentConnection(prev => prev ? { ...prev, includeReceipt: newIncludeReceipt } : prev);
+                setStatus(newIncludeReceipt
+                    ? 'Receipts will be included in the payload.'
+                    : 'Receipts will not be included in the payload.');
+            });
+        } catch (error) {
+            console.error('Error toggling include receipt:', error);
+            setStatus('Error saving toggle');
+            setIncludeReceipt(!newIncludeReceipt);
+        }
+    };
+
     const handleSave = async () => {
         // If no new URL entered but connection exists, just close (no changes)
         if (!url.trim() && currentConnection) {
@@ -119,6 +154,7 @@ export default function PowerAutomateConfigModal({ isOpen, onClose }) {
                     type: 'power-automate',
                     url: url,
                     enabled: enabled,
+                    includeReceipt: includeReceipt,
                     actions: [],
                     history: []
                 };
@@ -211,6 +247,31 @@ export default function PowerAutomateConfigModal({ isOpen, onClose }) {
                                             type="checkbox"
                                             checked={enabled}
                                             onChange={(e) => handleToggleEnabled(e.target.checked)}
+                                            className="sr-only peer"
+                                        />
+                                        <div className="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                                    </div>
+                                </label>
+                            </div>
+                        )}
+
+                        {currentConnection && (
+                            <div className="mb-4 p-3 rounded-md bg-gray-50 border border-gray-200">
+                                <label htmlFor="pa-receipt-toggle" className="flex items-center justify-between cursor-pointer">
+                                    <span className="text-sm">
+                                        <span className="font-medium text-gray-700 block">Include Receipts</span>
+                                        <span className="text-xs text-gray-500">
+                                            {includeReceipt
+                                                ? 'A PDF receipt is attached to the payload sent to Power Automate.'
+                                                : 'No receipt is included in the payload.'}
+                                        </span>
+                                    </span>
+                                    <div className="relative inline-flex items-center flex-shrink-0 ml-3">
+                                        <input
+                                            id="pa-receipt-toggle"
+                                            type="checkbox"
+                                            checked={includeReceipt}
+                                            onChange={(e) => handleToggleIncludeReceipt(e.target.checked)}
                                             className="sr-only peer"
                                         />
                                         <div className="w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-300 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>


### PR DESCRIPTION
## Summary
Add an "Include Receipts" toggle to the Power Automate configuration modal, allowing users to control whether a base64-encoded PDF receipt is attached to payloads sent to Power Automate. Receipt inclusion is off by default.

## Changes
- **PersonalizedEmail.jsx**: Wrap PDF receipt generation in both the main send flow and test send flow behind a conditional check of `powerAutomateConnection?.includeReceipt`. Only generate and attach the receipt if the toggle is explicitly enabled.
- **PowerAutomateConfigModal.jsx**: 
  - Add `includeReceipt` state (defaults to `false`)
  - Load and persist the `includeReceipt` setting from/to the workbook's "connections" storage
  - Implement `handleToggleIncludeReceipt` to update the setting when the toggle changes
  - Render a new toggle UI section (visible only when a connection is configured) with contextual help text showing whether receipts will be included
  - Include `includeReceipt` in the connection object when saving a new configuration

## Implementation Details
- The receipt toggle only appears in the UI when a Power Automate connection is already configured
- Toggle state is persisted to Excel workbook settings alongside the connection configuration
- Both the main email send and test send flows respect the same `includeReceipt` flag
- Default behavior (receipts off) reduces payload size for users who don't need receipts

https://claude.ai/code/session_018JUeE6iqJJ9QRzZoERGD7U