### PR TITLE
Compress oversized pasted images in email body

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -5,6 +5,7 @@ import PillInput from './components/PillInput';
 import { EMAIL_TEMPLATES_KEY, CUSTOM_PARAMS_KEY, LAST_EMAIL_SENT_KEY, standardParameters, specialParameters, QUILL_EDITOR_CONFIG, PARAMETER_BUTTON_STYLES, COLUMN_MAPPINGS } from './utils/constants';
 import { findColumnIndex, normalizeHeader, getTodaysLdaSheetName, formatLastSentStamp, getNameParts, isValidEmail, isValidHttpUrl, evaluateMapping, renderTemplate, renderCCTemplate, generateMissingAssignmentsList, buildMissingAssignmentsCache } from './utils/helpers';
 import { generatePdfReceipt } from './utils/receiptGenerator';
+import { compressDataUriImage, dataUriByteLength, formatBytes, IMAGE_COMPRESS_THRESHOLD_BYTES } from './utils/imageCompression';
 import { downloadMailMergeTemplate, extractFieldNames } from './utils/docxGenerator';
 import { downloadRecipientsXlsx } from './utils/recipientsGenerator';
 import DownloadModal from './modals/DownloadModal';
@@ -57,6 +58,13 @@ export default function PersonalizedEmail({ user, onReady }) {
     const [showSendContextMenu, setShowSendContextMenu] = useState(false);
     const [showSendTooltip, setShowSendTooltip] = useState(false);
     const quillRef = useRef(null);
+    const [imageNotice, setImageNotice] = useState('');
+    const imageNoticeTimerRef = useRef(null);
+    const compressImagesTimerRef = useRef(null);
+    const isCompressingImagesRef = useRef(false);
+    // Tracks data-URIs we've already tried (and failed) to shrink, so a stubborn
+    // image can't trigger an endless compress loop.
+    const failedImagesRef = useRef(new Set());
     const recipientButtonRef = useRef(null);
     const sendButtonRef = useRef(null);
     const tooltipRef = useRef(null);
@@ -113,6 +121,12 @@ export default function PersonalizedEmail({ user, onReady }) {
         document.addEventListener('mousedown', handleClickOutside);
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [showSendContextMenu]);
+
+    // Clear pending image-compression timers on unmount.
+    useEffect(() => () => {
+        if (imageNoticeTimerRef.current) clearTimeout(imageNoticeTimerRef.current);
+        if (compressImagesTimerRef.current) clearTimeout(compressImagesTimerRef.current);
+    }, []);
 
     // Setup automatic parameter highlighting
     useEffect(() => {
@@ -875,6 +889,108 @@ export default function PersonalizedEmail({ user, onReady }) {
         }
     };
 
+    // --- Image compression -------------------------------------------------
+    // Pasted images embed as large base64 data-URIs. Because the body is copied
+    // into every recipient's payload entry, an oversized image multiplies fast
+    // and can overflow JSON.stringify (RangeError: Invalid string length). We
+    // downscale/re-encode anything over the threshold right after it lands in
+    // the editor, and surface a notice so the user knows it happened.
+
+    const showImageNotice = (message) => {
+        setImageNotice(message);
+        if (imageNoticeTimerRef.current) clearTimeout(imageNoticeTimerRef.current);
+        imageNoticeTimerRef.current = setTimeout(() => setImageNotice(''), 6000);
+    };
+
+    // Returns the document index + src of every image embed in the editor.
+    const getImageEmbeds = (editor) => {
+        const embeds = [];
+        let index = 0;
+        const delta = editor.getContents();
+        (delta.ops || []).forEach(op => {
+            if (op.insert && typeof op.insert === 'object' && typeof op.insert.image === 'string') {
+                embeds.push({ index, src: op.insert.image });
+                index += 1;
+            } else if (typeof op.insert === 'string') {
+                index += op.insert.length;
+            } else {
+                index += 1;
+            }
+        });
+        return embeds;
+    };
+
+    const findOversizedImage = (editor) => getImageEmbeds(editor).find(e =>
+        e.src.startsWith('data:image') &&
+        !failedImagesRef.current.has(e.src) &&
+        dataUriByteLength(e.src) > IMAGE_COMPRESS_THRESHOLD_BYTES
+    );
+
+    const compressOversizedImages = async () => {
+        const editor = quillRef.current?.getEditor?.();
+        if (!editor || isCompressingImagesRef.current) return;
+        if (!findOversizedImage(editor)) return;
+
+        isCompressingImagesRef.current = true;
+        let changed = false;
+        try {
+            // Re-scan each pass so images added mid-compression are still caught;
+            // the guard counter is just a safety stop against pathological loops.
+            for (let guard = 0; guard < 50; guard++) {
+                const target = findOversizedImage(editor);
+                if (!target) break;
+
+                const originalBytes = dataUriByteLength(target.src);
+                showImageNotice(`Large image detected (${formatBytes(originalBytes)}) — compressing…`);
+
+                let newSrc = null;
+                try {
+                    newSrc = await compressDataUriImage(target.src);
+                } catch (error) {
+                    console.error('Image compression failed:', error);
+                    newSrc = null;
+                }
+
+                // Re-locate the embed: the user may have edited during the await.
+                const current = getImageEmbeds(editor).find(e => e.src === target.src);
+                const newBytes = newSrc ? dataUriByteLength(newSrc) : Infinity;
+
+                if (newSrc && current && newBytes < originalBytes) {
+                    editor.deleteText(current.index, 1, 'silent');
+                    editor.insertEmbed(current.index, 'image', newSrc, 'silent');
+                    changed = true;
+                    if (newBytes > IMAGE_COMPRESS_THRESHOLD_BYTES) {
+                        // Still over the limit (rare) — keep it but don't reprocess.
+                        failedImagesRef.current.add(newSrc);
+                        showImageNotice(`Image compressed to ${formatBytes(newBytes)} (still large — consider a smaller image).`);
+                    } else {
+                        showImageNotice(`Large image compressed: ${formatBytes(originalBytes)} → ${formatBytes(newBytes)}.`);
+                    }
+                } else {
+                    // Couldn't load/encode, or no size gain — give up on this one
+                    // so the loop can't spin on it.
+                    failedImagesRef.current.add(target.src);
+                    showImageNotice(`Couldn't compress an image (${formatBytes(originalBytes)}). It may be too large to send.`);
+                }
+            }
+
+            if (changed) {
+                // Our edits were 'silent', so push the new HTML back into React state.
+                setBody(editor.root.innerHTML);
+            }
+        } finally {
+            isCompressingImagesRef.current = false;
+        }
+    };
+
+    // Wraps the Quill onChange: keep React state in sync, then (debounced) shrink
+    // any oversized pasted/dropped images.
+    const handleBodyChange = (value) => {
+        setBody(value);
+        if (compressImagesTimerRef.current) clearTimeout(compressImagesTimerRef.current);
+        compressImagesTimerRef.current = setTimeout(() => { compressOversizedImages(); }, 250);
+    };
+
     const stripParameterBackgrounds = (html) => {
         // Create a temporary div to parse HTML
         const tempDiv = document.createElement('div');
@@ -906,10 +1022,15 @@ export default function PersonalizedEmail({ user, onReady }) {
         return tempDiv.innerHTML;
     };
 
-    const generatePayload = () => {
+    // Reads the body straight from the editor so callers always get the latest
+    // content — including image compression done with 'silent' edits that React
+    // state hasn't caught up to yet.
+    const getCurrentBodyHtml = () => quillRef.current?.getEditor?.()?.root.innerHTML ?? body;
+
+    const generatePayload = (bodyHtml = body) => {
         const fromTemplate = fromPills[0] || '';
         // Strip parameter backgrounds from body before rendering
-        const cleanBodyHtml = stripParameterBackgrounds(body);
+        const cleanBodyHtml = stripParameterBackgrounds(bodyHtml);
 
         const emails = studentDataCache.map(student => ({
             from: renderTemplate(fromTemplate, student),
@@ -944,7 +1065,11 @@ export default function PersonalizedEmail({ user, onReady }) {
         setShowConfirmModal(false);
         setStatus(`Sending ${studentDataCache.length} emails...`);
 
-        const payload = generatePayload();
+        // Shrink any oversized images before building the payload, in case the
+        // user pasted one and hit Send before the debounced compression ran.
+        await compressOversizedImages();
+        const currentBody = getCurrentBodyHtml();
+        const payload = generatePayload(currentBody);
 
         if (payload.emails.length === 0) {
             setStatus('No students with valid "To" and "From" email addresses found.');
@@ -958,7 +1083,7 @@ export default function PersonalizedEmail({ user, onReady }) {
             const initiator = { name: user, email: userEmail };
             const receiptBase64 = generatePdfReceipt(
                 payload.emails,
-                body,
+                currentBody,
                 initiator,
                 true // returnBase64
             );
@@ -1061,6 +1186,10 @@ export default function PersonalizedEmail({ user, onReady }) {
         // Ensure student data is loaded
         await ensureStudentDataLoaded();
 
+        // Shrink any oversized images before building the payload.
+        await compressOversizedImages();
+        const currentBody = getCurrentBodyHtml();
+
         // Pick a random student for parameter replacement, or use a placeholder if no students
         let testStudent;
         if (studentDataCache.length > 0) {
@@ -1078,7 +1207,7 @@ export default function PersonalizedEmail({ user, onReady }) {
 
         // Generate single test email payload with user's email as recipient
         const fromTemplate = fromPills[0] || '';
-        const cleanBodyHtml = stripParameterBackgrounds(body);
+        const cleanBodyHtml = stripParameterBackgrounds(currentBody);
         const testFromEmail = renderTemplate(fromTemplate, testStudent);
 
         const testPayload = {
@@ -1107,7 +1236,7 @@ export default function PersonalizedEmail({ user, onReady }) {
                     const initiator = { name: user, email: userEmail };
                     const receiptBase64 = generatePdfReceipt(
                         testPayload.emails,
-                        body,
+                        currentBody,
                         initiator,
                         true // returnBase64
                     );
@@ -1315,12 +1444,20 @@ export default function PersonalizedEmail({ user, onReady }) {
                         ref={quillRef}
                         theme="snow"
                         value={body}
-                        onChange={setBody}
+                        onChange={handleBodyChange}
                         onFocus={() => setLastFocusedInput('quill')}
                         modules={QUILL_EDITOR_CONFIG.modules}
                         className="mt-1 bg-white"
                         style={{ height: '192px', marginBottom: '48px' }}
                     />
+                    {imageNotice && (
+                        <div className="mt-1 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                            <svg className="h-4 w-4 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                            </svg>
+                            <span>{imageNotice}</span>
+                        </div>
+                    )}
                 </div>
 
                 {/* Parameters — collapsed by default so users with saved templates have more space */}

--- a/react/src/components/personalizedEmail/utils/__tests__/imageCompression.test.js
+++ b/react/src/components/personalizedEmail/utils/__tests__/imageCompression.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+    dataUriByteLength,
+    formatBytes,
+    IMAGE_COMPRESS_THRESHOLD_BYTES,
+} from '../imageCompression';
+
+describe('dataUriByteLength', () => {
+    it('returns 0 for empty / invalid input', () => {
+        expect(dataUriByteLength('')).toBe(0);
+        expect(dataUriByteLength(null)).toBe(0);
+        expect(dataUriByteLength(undefined)).toBe(0);
+        expect(dataUriByteLength(12345)).toBe(0);
+    });
+
+    it('computes decoded byte length from a data-URI, accounting for padding', () => {
+        // "AAAA" (no padding) -> 3 bytes
+        expect(dataUriByteLength('data:image/png;base64,AAAA')).toBe(3);
+        // "AAA=" -> 2 bytes, "AA==" -> 1 byte
+        expect(dataUriByteLength('data:image/png;base64,AAA=')).toBe(2);
+        expect(dataUriByteLength('data:image/png;base64,AA==')).toBe(1);
+    });
+
+    it('accepts a bare base64 string (no data-URI prefix)', () => {
+        expect(dataUriByteLength('AAAA')).toBe(3);
+    });
+
+    it('scales with payload length', () => {
+        // 1000 groups of 4 base64 chars, no padding -> 3000 bytes
+        expect(dataUriByteLength(`data:image/jpeg;base64,${'AAAA'.repeat(1000)}`)).toBe(3000);
+    });
+});
+
+describe('formatBytes', () => {
+    it('formats common sizes', () => {
+        expect(formatBytes(0)).toBe('0 B');
+        expect(formatBytes(-5)).toBe('0 B');
+        expect(formatBytes(512)).toBe('512 B');
+        expect(formatBytes(1024)).toBe('1 KB');
+        expect(formatBytes(1536)).toBe('1.5 KB');
+        expect(formatBytes(5 * 1024 * 1024)).toBe('5 MB');
+    });
+});
+
+describe('IMAGE_COMPRESS_THRESHOLD_BYTES', () => {
+    it('is a sensible positive threshold', () => {
+        expect(IMAGE_COMPRESS_THRESHOLD_BYTES).toBeGreaterThan(0);
+    });
+});

--- a/react/src/components/personalizedEmail/utils/imageCompression.js
+++ b/react/src/components/personalizedEmail/utils/imageCompression.js
@@ -1,0 +1,106 @@
+// Image compression helpers for the email body editor.
+//
+// Pasted/dropped images land in the Quill body as base64 data-URIs. The body is
+// duplicated into every recipient's payload entry, so a single large image gets
+// copied N times and can push JSON.stringify past V8's max string length
+// (~512MB) — the whole send then fails with "RangeError: Invalid string
+// length". To keep payloads small, images larger than
+// IMAGE_COMPRESS_THRESHOLD_BYTES are downscaled and re-encoded as JPEG before
+// they're embedded.
+
+// Images larger than this (decoded byte size) are compressed on insert.
+export const IMAGE_COMPRESS_THRESHOLD_BYTES = 500 * 1024; // 500 KB
+
+/**
+ * Approximate decoded byte length of a base64 data-URI (or bare base64 string).
+ * @param {string} dataUri
+ * @returns {number}
+ */
+export function dataUriByteLength(dataUri) {
+    if (!dataUri || typeof dataUri !== 'string') return 0;
+    const commaIndex = dataUri.indexOf(',');
+    const base64 = commaIndex >= 0 ? dataUri.slice(commaIndex + 1) : dataUri;
+    const length = base64.length;
+    if (length === 0) return 0;
+    let padding = 0;
+    if (base64.endsWith('==')) padding = 2;
+    else if (base64.endsWith('=')) padding = 1;
+    return Math.max(0, Math.floor((length * 3) / 4) - padding);
+}
+
+/**
+ * Human-readable byte size, e.g. "4.2 MB".
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function formatBytes(bytes) {
+    if (!bytes || bytes <= 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / Math.pow(1024, exponent);
+    const rounded = exponent === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+    return `${rounded} ${units[exponent]}`;
+}
+
+/**
+ * Downscale + re-encode a base64 image data-URI so it's small enough to embed in
+ * the email payload. Resolves to a new JPEG data-URI, or rejects if the image
+ * can't be loaded/encoded (e.g. a tainted or unsupported source).
+ *
+ * Uses the browser canvas, so it only runs inside the Office task pane.
+ * @param {string} dataUri
+ * @param {{ maxDimension?: number, quality?: number }} [options]
+ * @returns {Promise<string>}
+ */
+export function compressDataUriImage(dataUri, { maxDimension = 1280, quality = 0.72 } = {}) {
+    return new Promise((resolve, reject) => {
+        if (typeof document === 'undefined' || typeof Image === 'undefined') {
+            reject(new Error('Image compression is not available in this environment.'));
+            return;
+        }
+
+        const img = new Image();
+        img.onload = () => {
+            try {
+                let width = img.naturalWidth || img.width;
+                let height = img.naturalHeight || img.height;
+                if (!width || !height) {
+                    reject(new Error('Image has no intrinsic size.'));
+                    return;
+                }
+
+                // Scale the longest edge down to maxDimension, preserving aspect ratio.
+                if (width > maxDimension || height > maxDimension) {
+                    if (width >= height) {
+                        height = Math.round((height * maxDimension) / width);
+                        width = maxDimension;
+                    } else {
+                        width = Math.round((width * maxDimension) / height);
+                        height = maxDimension;
+                    }
+                }
+
+                const canvas = document.createElement('canvas');
+                canvas.width = width;
+                canvas.height = height;
+                const ctx = canvas.getContext('2d');
+                // JPEG has no alpha channel; flatten transparency onto white so
+                // transparent PNGs don't render with a black background.
+                ctx.fillStyle = '#ffffff';
+                ctx.fillRect(0, 0, width, height);
+                ctx.drawImage(img, 0, 0, width, height);
+
+                const result = canvas.toDataURL('image/jpeg', quality);
+                if (!result || !result.startsWith('data:image/jpeg')) {
+                    reject(new Error('Failed to encode compressed image.'));
+                    return;
+                }
+                resolve(result);
+            } catch (error) {
+                reject(error);
+            }
+        };
+        img.onerror = () => reject(new Error('Failed to load image for compression.'));
+        img.src = dataUri;
+    });
+}


### PR DESCRIPTION
Fixes "RangeError: Invalid string length" when sending emails that contain a pasted image. Images embed into the Quill body as base64 data-URIs, and generatePayload copies that body into every recipient entry — so one large image multiplied across recipients overflowed JSON.stringify (~512MB cap).

- New utils/imageCompression.js: dataUriByteLength, formatBytes, and compressDataUriImage (canvas downscale to <=1280px + JPEG re-encode).
- PersonalizedEmail: after edits (debounced) and again right before send, shrink any data-URI image over 500KB in place and surface an amber notice telling the user it was compressed (e.g. "4.2 MB -> 180 KB").
- Send/test paths build the payload and receipt from the live editor HTML so an immediate Send after a paste still uses the compressed image.
- Unit tests for the pure byte-size/format helpers.


Claude-Session: https://claude.ai/code/session_018JUeE6iqJJ9QRzZoERGD7U