### PR TITLE
Render pictures and emoji in the PDF receipt

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -1081,7 +1081,7 @@ export default function PersonalizedEmail({ user, onReady }) {
         let payloadToSend = payload;
         if (powerAutomateConnection?.includeReceipt === true) {
             const initiator = { name: user, email: userEmail };
-            const receiptBase64 = generatePdfReceipt(
+            const receiptBase64 = await generatePdfReceipt(
                 payload.emails,
                 currentBody,
                 initiator,
@@ -1234,7 +1234,7 @@ export default function PersonalizedEmail({ user, onReady }) {
                 let testPayloadToSend = testPayload;
                 if (powerAutomateConnection?.includeReceipt === true) {
                     const initiator = { name: user, email: userEmail };
-                    const receiptBase64 = generatePdfReceipt(
+                    const receiptBase64 = await generatePdfReceipt(
                         testPayload.emails,
                         currentBody,
                         initiator,

--- a/react/src/components/personalizedEmail/modals/SuccessModal.jsx
+++ b/react/src/components/personalizedEmail/modals/SuccessModal.jsx
@@ -4,10 +4,10 @@ import { generatePdfReceipt } from '../utils/receiptGenerator';
 export default function SuccessModal({ isOpen, onClose, count, payload, bodyTemplate, initiator }) {
     if (!isOpen) return null;
 
-    const handleDownloadReceipt = () => {
+    const handleDownloadReceipt = async () => {
         // payload now has structure { byName, byEmail, emails }, so pass emails array
         const emails = payload?.emails || payload;
-        generatePdfReceipt(emails, bodyTemplate, initiator || {});
+        await generatePdfReceipt(emails, bodyTemplate, initiator || {});
     };
 
     return (

--- a/react/src/components/personalizedEmail/utils/__tests__/emojiText.test.js
+++ b/react/src/components/personalizedEmail/utils/__tests__/emojiText.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { isEmojiCluster, tokenizeRichText } from '../emojiText';
+
+describe('isEmojiCluster', () => {
+    it('detects pictographic emoji', () => {
+        expect(isEmojiCluster('🎉')).toBe(true);
+        expect(isEmojiCluster('👍')).toBe(true);
+        expect(isEmojiCluster('❤️')).toBe(true);
+    });
+
+    it('rejects plain text, digits, and whitespace', () => {
+        expect(isEmojiCluster('a')).toBe(false);
+        expect(isEmojiCluster('5')).toBe(false);
+        expect(isEmojiCluster('#')).toBe(false);
+        expect(isEmojiCluster(' ')).toBe(false);
+        expect(isEmojiCluster('')).toBe(false);
+    });
+});
+
+describe('tokenizeRichText', () => {
+    it('splits words and spaces', () => {
+        expect(tokenizeRichText('hello world')).toEqual([
+            { type: 'text', value: 'hello' },
+            { type: 'space', value: ' ' },
+            { type: 'text', value: 'world' },
+        ]);
+    });
+
+    it('separates an emoji from adjacent text', () => {
+        expect(tokenizeRichText('hi👋there')).toEqual([
+            { type: 'text', value: 'hi' },
+            { type: 'emoji', value: '👋' },
+            { type: 'text', value: 'there' },
+        ]);
+    });
+
+    it('keeps a ZWJ sequence as a single emoji token', () => {
+        const tokens = tokenizeRichText('👨‍👩‍👧');
+        const emojiTokens = tokens.filter((t) => t.type === 'emoji');
+        expect(emojiTokens).toHaveLength(1);
+        expect(emojiTokens[0].value).toBe('👨‍👩‍👧');
+    });
+
+    it('handles empty input', () => {
+        expect(tokenizeRichText('')).toEqual([]);
+        expect(tokenizeRichText(null)).toEqual([]);
+    });
+});

--- a/react/src/components/personalizedEmail/utils/emojiText.js
+++ b/react/src/components/personalizedEmail/utils/emojiText.js
@@ -1,0 +1,63 @@
+// Emoji-aware text tokenization for the PDF receipt renderer.
+//
+// jsPDF's built-in fonts can't draw emoji, so the receipt renderer rasterizes
+// each emoji into a small image and places it inline. To do that it first needs
+// to split a text run into plain-text words, spaces, and individual emoji
+// grapheme clusters. These helpers are pure (no DOM/canvas) so they can be
+// unit-tested outside the Office host.
+
+// Extended_Pictographic covers the vast majority of emoji; Regional_Indicator
+// covers flag pairs. Plain ASCII — including digits and '#'/'*' — is excluded.
+const EMOJI_PATTERN = /(?:\p{Extended_Pictographic}|\p{Regional_Indicator})/u;
+
+/**
+ * True if a grapheme cluster is (or begins with) an emoji.
+ * @param {string} cluster
+ * @returns {boolean}
+ */
+export function isEmojiCluster(cluster) {
+    if (!cluster) return false;
+    return EMOJI_PATTERN.test(cluster);
+}
+
+function segmentGraphemes(str) {
+    if (typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function') {
+        const segmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+        return Array.from(segmenter.segment(str), (s) => s.segment);
+    }
+    // Fallback: split on code points (keeps surrogate pairs intact, but won't
+    // group ZWJ sequences — acceptable degradation on old runtimes).
+    return Array.from(str);
+}
+
+/**
+ * Split a string into ordered tokens: { type: 'text'|'space'|'emoji', value }.
+ * Runs of non-space, non-emoji graphemes are merged into one 'text' token;
+ * each emoji grapheme cluster (including ZWJ sequences) is its own token.
+ * @param {string} str
+ * @returns {Array<{type: string, value: string}>}
+ */
+export function tokenizeRichText(str) {
+    const tokens = [];
+    let textBuffer = '';
+    const flushText = () => {
+        if (textBuffer) {
+            tokens.push({ type: 'text', value: textBuffer });
+            textBuffer = '';
+        }
+    };
+
+    for (const grapheme of segmentGraphemes(str || '')) {
+        if (grapheme === ' ') {
+            flushText();
+            tokens.push({ type: 'space', value: ' ' });
+        } else if (isEmojiCluster(grapheme)) {
+            flushText();
+            tokens.push({ type: 'emoji', value: grapheme });
+        } else {
+            textBuffer += grapheme;
+        }
+    }
+    flushText();
+    return tokens;
+}

--- a/react/src/components/personalizedEmail/utils/receiptGenerator.js
+++ b/react/src/components/personalizedEmail/utils/receiptGenerator.js
@@ -1,17 +1,117 @@
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import { getTodaysLdaSheetName } from './helpers';
+import { tokenizeRichText } from './emojiText';
+
+// Cache of rasterized emoji so the same glyph isn't re-rendered to a canvas
+// repeatedly within one receipt. Keyed by `${emoji}@${size}`.
+const emojiImageCache = new Map();
+
+/**
+ * Rasterize a single emoji to a PNG data-URI using the canvas. In the Office
+ * task pane (a Chromium/WebView2 webview) canvas text uses the OS color-emoji
+ * font (Segoe UI Emoji / Apple Color Emoji), so this yields full-color emoji,
+ * falling back to whatever monochrome glyph the platform provides. Returns null
+ * if no canvas is available (e.g. unit tests).
+ * @param {string} emoji
+ * @param {number} sizePx
+ * @returns {string|null}
+ */
+function emojiToDataUrl(emoji, sizePx) {
+    if (typeof document === 'undefined') return null;
+    const key = `${emoji}@${sizePx}`;
+    if (emojiImageCache.has(key)) return emojiImageCache.get(key);
+
+    try {
+        const scale = 3; // render larger then downscale for crisp glyphs
+        const dim = Math.max(8, Math.round(sizePx)) * scale;
+        const canvas = document.createElement('canvas');
+        canvas.width = dim;
+        canvas.height = dim;
+        const ctx = canvas.getContext('2d');
+        ctx.clearRect(0, 0, dim, dim);
+        ctx.textBaseline = 'alphabetic';
+        ctx.textAlign = 'left';
+        ctx.font = `${Math.round(dim * 0.82)}px "Segoe UI Emoji","Apple Color Emoji","Noto Color Emoji","Twemoji Mozilla","EmojiOne Color",sans-serif`;
+        ctx.fillText(emoji, dim * 0.04, dim * 0.86);
+        const url = canvas.toDataURL('image/png');
+        emojiImageCache.set(key, url);
+        return url;
+    } catch (err) {
+        emojiImageCache.set(key, null);
+        return null;
+    }
+}
+
+/**
+ * Load an image source (data-URI or URL) into an HTMLImageElement.
+ * Resolves to the element once decoded, or null if it can't be loaded.
+ * @param {string} src
+ * @returns {Promise<HTMLImageElement|null>}
+ */
+function loadImageElement(src) {
+    return new Promise((resolve) => {
+        if (typeof Image === 'undefined') {
+            resolve(null);
+            return;
+        }
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => resolve(img);
+        img.onerror = () => resolve(null);
+        img.src = src;
+    });
+}
+
+/**
+ * Pre-load every <img> referenced by the given HTML strings so the (synchronous)
+ * renderer can draw them with known dimensions. Returns a Map keyed by src.
+ * @param {Array<string>} htmlStrings
+ * @returns {Promise<Map<string, {img: HTMLImageElement, dataUri: string, format: string, width: number, height: number}>>}
+ */
+async function prepareReceiptImageMap(htmlStrings) {
+    const map = new Map();
+    if (typeof DOMParser === 'undefined') return map;
+
+    const srcSet = new Set();
+    (htmlStrings || []).forEach((html) => {
+        if (!html || typeof html !== 'string' || !html.includes('<img')) return;
+        const parsed = new DOMParser().parseFromString(html, 'text/html');
+        parsed.querySelectorAll('img').forEach((img) => {
+            const src = img.getAttribute('src');
+            if (src) srcSet.add(src);
+        });
+    });
+
+    const srcList = Array.from(srcSet);
+    await Promise.all(srcList.map(async (src, index) => {
+        const img = await loadImageElement(src);
+        const width = img ? (img.naturalWidth || img.width) : 0;
+        const height = img ? (img.naturalHeight || img.height) : 0;
+        if (img && width && height) {
+            const formatMatch = src.match(/^data:image\/(\w+)/i);
+            const format = (formatMatch ? formatMatch[1] : 'png').toUpperCase().replace('JPG', 'JPEG');
+            // Short, stable alias so jsPDF embeds each image once even when it
+            // appears in both the template body and the example body.
+            map.set(src, { img, dataUri: src, format, width, height, alias: `receipt-img-${index}` });
+        }
+    }));
+
+    return map;
+}
 
 /**
  * Renders an HTML string with basic formatting into a jsPDF document,
+
  * with automatic page breaks (no truncation).
  * @returns {number} The final Y position after rendering
  */
 function renderHtmlInPdf(doc, html, options) {
-    let { startX, startY, maxWidth, margin, pageHeight } = options;
+    let { startX, startY, maxWidth, margin, pageHeight, imageMap } = options;
     let currentY = startY;
     const lineHeight = 12;
     const paragraphSpacing = 18;
+    const emojiSize = Math.round(lineHeight * 0.9);
 
     const tempDiv = document.createElement('div');
     tempDiv.style.display = 'none';
@@ -25,7 +125,90 @@ function renderHtmlInPdf(doc, html, options) {
         }
     };
 
+    // Draw an <img> as its own block, scaled to fit the content width (and page
+    // height). Advances currentY past the image; returns the reset currentX.
+    const drawImage = (node, currentX) => {
+        const src = node.getAttribute('src');
+        const entry = src && imageMap ? imageMap.get(src) : null;
+        if (!entry || !entry.width || !entry.height) return currentX;
+
+        if (currentX > startX) {
+            currentY += lineHeight;
+            currentX = startX;
+        }
+
+        const attrW = parseInt(node.getAttribute('width'), 10);
+        let dispW = attrW && attrW > 0 ? attrW : entry.width;
+        if (dispW > maxWidth) dispW = maxWidth;
+        let dispH = entry.height * (dispW / entry.width);
+
+        const maxImgHeight = pageHeight - margin * 2;
+        if (dispH > maxImgHeight) {
+            dispW = dispW * (maxImgHeight / dispH);
+            dispH = maxImgHeight;
+        }
+
+        // Push a tall image onto a fresh page rather than clipping it.
+        if (currentY + dispH > pageHeight - margin) {
+            doc.addPage();
+            currentY = margin;
+        }
+
+        try {
+            doc.addImage(entry.img, entry.format, startX, currentY, dispW, dispH, entry.alias);
+        } catch (err) {
+            try {
+                doc.addImage(entry.dataUri, entry.format, startX, currentY, dispW, dispH, entry.alias);
+            } catch (err2) {
+                console.warn('Failed to render image in receipt:', err2);
+            }
+        }
+
+        currentY += dispH + 4;
+        return startX;
+    };
+
+    // Render a plain-text run, drawing emoji as inline images and wrapping words.
+    const drawTextRun = (text, currentX) => {
+        const tokens = tokenizeRichText(text);
+        for (const token of tokens) {
+            if (token.type === 'space') {
+                if (currentX > startX) currentX += doc.getTextWidth(' ');
+            } else if (token.type === 'emoji') {
+                if (currentX > startX && currentX + emojiSize > startX + maxWidth) {
+                    currentY += lineHeight;
+                    currentX = startX;
+                    checkPageBreak();
+                }
+                const url = emojiToDataUrl(token.value, emojiSize);
+                if (url) {
+                    try {
+                        // Alias keyed by glyph+size so a repeated emoji is embedded once.
+                        doc.addImage(url, 'PNG', currentX, currentY - emojiSize * 0.85, emojiSize, emojiSize, `emoji-${token.value}-${emojiSize}`);
+                    } catch (err) {
+                        // Skip an emoji we can't place rather than aborting the receipt.
+                    }
+                }
+                currentX += emojiSize;
+            } else {
+                const wordWidth = doc.getTextWidth(token.value);
+                if (currentX > startX && currentX + wordWidth > startX + maxWidth) {
+                    currentY += lineHeight;
+                    currentX = startX;
+                    checkPageBreak();
+                }
+                doc.text(token.value, currentX, currentY);
+                currentX += wordWidth;
+            }
+        }
+        return currentX;
+    };
+
     const processNode = (node, currentX, styles) => {
+        if (node.nodeType === 1 && node.tagName === 'IMG') {
+            return drawImage(node, currentX);
+        }
+
         const isBold = styles.isBold || node.tagName === 'STRONG' || node.tagName === 'B';
         const isItalic = styles.isItalic || node.tagName === 'EM' || node.tagName === 'I';
         let fontStyle = 'normal';
@@ -34,7 +217,7 @@ function renderHtmlInPdf(doc, html, options) {
         else if (isItalic) fontStyle = 'italic';
 
         if (node.nodeType === 3) {
-            let textContent = (node.textContent || '').replace(/\s+/g, ' ');
+            const textContent = (node.textContent || '').replace(/\s+/g, ' ');
 
             // Split text by parameter patterns {ParameterName}, keeping delimiters
             const paramRegex = /(\{[^}]+\})/g;
@@ -52,7 +235,7 @@ function renderHtmlInPdf(doc, html, options) {
 
                     // Render parameter as a single unit (no trailing space)
                     const partWidth = doc.getTextWidth(part);
-                    if (currentX + partWidth > startX + maxWidth) {
+                    if (currentX > startX && currentX + partWidth > startX + maxWidth) {
                         currentY += lineHeight;
                         currentX = startX;
                         checkPageBreak();
@@ -61,38 +244,7 @@ function renderHtmlInPdf(doc, html, options) {
                     currentX += partWidth;
                 } else {
                     doc.setTextColor(0); // Black for regular text
-
-                    // Process regular text word by word
-                    const words = part.split(' ');
-                    for (let i = 0; i < words.length; i++) {
-                        const word = words[i];
-                        if (!word) {
-                            // Empty string means there was a space - add space width
-                            if (i > 0 || partIndex > 0) {
-                                const spaceWidth = doc.getTextWidth(' ');
-                                currentX += spaceWidth;
-                            }
-                            continue;
-                        }
-
-                        // Add space before word if not at start and previous was non-empty
-                        const needsLeadingSpace = i > 0 && words[i - 1] !== '';
-                        const textToRender = needsLeadingSpace ? ' ' + word : word;
-                        const wordWidth = doc.getTextWidth(textToRender);
-
-                        if (currentX + wordWidth > startX + maxWidth) {
-                            currentY += lineHeight;
-                            currentX = startX;
-                            checkPageBreak();
-                            // Don't add leading space at start of new line
-                            const trimmedText = textToRender.trimStart();
-                            doc.text(trimmedText, currentX, currentY);
-                            currentX += doc.getTextWidth(trimmedText);
-                        } else {
-                            doc.text(textToRender, currentX, currentY);
-                            currentX += wordWidth;
-                        }
-                    }
+                    currentX = drawTextRun(part, currentX);
                 }
             }
         } else {
@@ -121,6 +273,10 @@ function renderHtmlInPdf(doc, html, options) {
                     currentY += paragraphSpacing;
                 });
                 break;
+            case 'IMG':
+                drawImage(element, startX);
+                currentY += 4;
+                break;
             default:
                 processNode(element, startX, {});
                 currentY += paragraphSpacing;
@@ -134,7 +290,7 @@ function renderHtmlInPdf(doc, html, options) {
 /**
  * Estimates the height needed to render HTML content
  */
-function estimateHtmlHeight(doc, html, maxWidth) {
+function estimateHtmlHeight(doc, html, maxWidth, imageMap) {
     const lineHeight = 12;
     const paragraphSpacing = 18;
     let estimatedHeight = 0;
@@ -158,6 +314,13 @@ function estimateHtmlHeight(doc, html, maxWidth) {
                 }
                 currentX += wordWidth;
             }
+        } else if (node.nodeType === 1 && node.tagName === 'IMG') {
+            const entry = imageMap ? imageMap.get(node.getAttribute('src')) : null;
+            if (entry && entry.width && entry.height) {
+                const dispW = Math.min(entry.width, maxWidth);
+                estimatedHeight += entry.height * (dispW / entry.width) + 4;
+            }
+            currentX = 0;
         } else {
             for (const child of Array.from(node.childNodes)) {
                 currentX = estimateNodeHeight(child, currentX);
@@ -181,13 +344,17 @@ function estimateHtmlHeight(doc, html, maxWidth) {
  * @param {string} bodyTemplate - The email body template
  * @param {Object} initiator - Object with name and email of who initiated the send
  * @param {boolean} returnBase64 - If true, returns base64 string instead of saving
- * @returns {string|undefined} - Base64 string if returnBase64 is true, undefined otherwise
+ * @returns {Promise<string|undefined>} - Base64 string if returnBase64 is true, undefined otherwise
  */
-export function generatePdfReceipt(emails, bodyTemplate, initiator = {}, returnBase64 = false) {
+export async function generatePdfReceipt(emails, bodyTemplate, initiator = {}, returnBase64 = false) {
     if (!emails || emails.length === 0) {
         console.error("Emails array is empty. Cannot generate PDF receipt.");
         return;
     }
+
+    // Pre-load any embedded images (template + a rendered body share the same
+    // <img> sources) so the synchronous renderer can draw them with real sizes.
+    const imageMap = await prepareReceiptImageMap([bodyTemplate, emails[0] && emails[0].body]);
 
     try {
         const doc = new jsPDF({ orientation: "portrait", unit: "px", format: "letter" });
@@ -268,7 +435,8 @@ export function generatePdfReceipt(emails, bodyTemplate, initiator = {}, returnB
             startY: currentY,
             maxWidth: contentWidth,
             margin: margin,
-            pageHeight: pageHeight
+            pageHeight: pageHeight,
+            imageMap: imageMap
         });
 
         currentY += 10;
@@ -278,7 +446,7 @@ export function generatePdfReceipt(emails, bodyTemplate, initiator = {}, returnB
             const randomStudentPayload = emails[Math.floor(Math.random() * emails.length)];
 
             // Estimate height needed for example section
-            const estimatedExampleHeight = estimateHtmlHeight(doc, randomStudentPayload.body, contentWidth);
+            const estimatedExampleHeight = estimateHtmlHeight(doc, randomStudentPayload.body, contentWidth, imageMap);
             const spaceRemaining = pageHeight - margin - currentY;
 
             // If example won't fit on current page, start new page
@@ -298,7 +466,8 @@ export function generatePdfReceipt(emails, bodyTemplate, initiator = {}, returnB
                 startY: currentY,
                 maxWidth: contentWidth,
                 margin: margin,
-                pageHeight: pageHeight
+                pageHeight: pageHeight,
+                imageMap: imageMap
             });
 
             currentY += 10;


### PR DESCRIPTION
The receipt previously dropped images (the HTML renderer only drew text nodes) and couldn't show emoji (jsPDF's built-in Helvetica is Latin-1 only).

- Pictures: pre-load embedded <img> data-URIs into an image map, then draw them with doc.addImage — scaled to the content width, with page breaks for tall images. generatePdfReceipt is now async (callers updated to await).
- Emoji: rasterize each emoji to a PNG via canvas and place it inline. In the Office webview canvas text uses the OS color-emoji font, so emoji render in color (monochrome fallback where the platform has no color glyphs) — no external assets or CDN needed. New emojiText.js provides a pure, unit-tested grapheme tokenizer (handles ZWJ sequences) that splits text/space/emoji.
- Images and emoji are added with jsPDF aliases so a glyph/image used more than once is embedded only once, keeping the receipt (which can travel in the payload) small.


Claude-Session: https://claude.ai/code/session_018JUeE6iqJJ9QRzZoERGD7U