### PR TITLE
Add {Signature} special parameter with per-From-address signatures

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import ReactQuill from 'react-quill-new';
 import 'react-quill-new/dist/quill.snow.css';
 import PillInput from './components/PillInput';
-import { EMAIL_TEMPLATES_KEY, CUSTOM_PARAMS_KEY, LAST_EMAIL_SENT_KEY, standardParameters, specialParameters, QUILL_EDITOR_CONFIG, PARAMETER_BUTTON_STYLES, COLUMN_MAPPINGS } from './utils/constants';
-import { findColumnIndex, normalizeHeader, getTodaysLdaSheetName, formatLastSentStamp, getNameParts, isValidEmail, isValidHttpUrl, evaluateMapping, renderTemplate, renderCCTemplate, generateMissingAssignmentsList, buildMissingAssignmentsCache } from './utils/helpers';
+import { EMAIL_TEMPLATES_KEY, CUSTOM_PARAMS_KEY, EMAIL_SIGNATURES_KEY, LAST_EMAIL_SENT_KEY, standardParameters, specialParameters, QUILL_EDITOR_CONFIG, PARAMETER_BUTTON_STYLES, COLUMN_MAPPINGS } from './utils/constants';
+import { findColumnIndex, normalizeHeader, getTodaysLdaSheetName, formatLastSentStamp, getNameParts, isValidEmail, isValidHttpUrl, evaluateMapping, renderTemplate, renderCCTemplate, findSignature, generateMissingAssignmentsList, buildMissingAssignmentsCache } from './utils/helpers';
 import { generatePdfReceipt } from './utils/receiptGenerator';
 import { compressDataUriImage, dataUriByteLength, formatBytes, IMAGE_COMPRESS_THRESHOLD_BYTES } from './utils/imageCompression';
 import { downloadMailMergeTemplate, extractFieldNames } from './utils/docxGenerator';
@@ -12,6 +12,7 @@ import DownloadModal from './modals/DownloadModal';
 import ExampleModal from './modals/ExampleModal';
 import TemplatesModal from './modals/TemplatesModal';
 import CustomParamModal from './modals/CustomParamModal';
+import SignatureModal from './modals/SignatureModal';
 import RecipientModal from './modals/RecipientModal';
 import ConfirmSendModal from './modals/ConfirmSendModal';
 import SuccessModal from './modals/SuccessModal';
@@ -38,6 +39,7 @@ export default function PersonalizedEmail({ user, onReady }) {
     const [studentDataCache, setStudentDataCache] = useState([]);
     const [cachedSpecialParams, setCachedSpecialParams] = useState([]);
     const [customParameters, setCustomParameters] = useState([]);
+    const [signatures, setSignatures] = useState([]);
     const [recipientSelection, setRecipientSelection] = useState({
         type: 'lda',
         customSheetName: '',
@@ -73,6 +75,7 @@ export default function PersonalizedEmail({ user, onReady }) {
     const [showExampleModal, setShowExampleModal] = useState(false);
     const [showTemplatesModal, setShowTemplatesModal] = useState(false);
     const [showCustomParamModal, setShowCustomParamModal] = useState(false);
+    const [showSignatureModal, setShowSignatureModal] = useState(false);
     const [showRecipientModal, setShowRecipientModal] = useState(false);
     const [showConfirmModal, setShowConfirmModal] = useState(false);
     const [showSuccessModal, setShowSuccessModal] = useState(false);
@@ -101,6 +104,7 @@ export default function PersonalizedEmail({ user, onReady }) {
             await Promise.all([
                 checkConnection(),
                 loadCustomParameters(),
+                loadSignatures(),
                 loadTemplates(),
                 loadLastSentInfo()
             ]);
@@ -285,6 +289,28 @@ export default function PersonalizedEmail({ user, onReady }) {
     const loadCustomParameters = async () => {
         const params = await getCustomParameters();
         setCustomParameters(params);
+    };
+
+    const loadSignatures = async () => {
+        try {
+            const loaded = await Excel.run(async (context) => {
+                const setting = context.workbook.settings.getItemOrNullObject(EMAIL_SIGNATURES_KEY);
+                setting.load("value");
+                await context.sync();
+                return setting.value ? JSON.parse(setting.value) : [];
+            });
+            setSignatures(Array.isArray(loaded) ? loaded : []);
+        } catch (error) {
+            console.error('Error loading signatures:', error);
+        }
+    };
+
+    const saveSignatures = async (newSignatures) => {
+        await Excel.run(async (context) => {
+            context.workbook.settings.add(EMAIL_SIGNATURES_KEY, JSON.stringify(newSignatures));
+            await context.sync();
+        });
+        setSignatures(newSignatures);
     };
 
     const loadTemplates = async () => {
@@ -778,7 +804,12 @@ export default function PersonalizedEmail({ user, onReady }) {
     };
 
     const handleOpenConfirmModal = async () => {
-        await ensureStudentDataLoaded();
+        const data = await ensureStudentDataLoaded();
+        const missing = getMissingSignatureFroms(data);
+        if (missing.length > 0) {
+            setStatus(`No signature set for: ${missing.join(', ')}. Add one with the pencil icon next to "Special Parameters" before sending.`);
+            return;
+        }
         setShowConfirmModal(true);
     };
 
@@ -1027,18 +1058,41 @@ export default function PersonalizedEmail({ user, onReady }) {
     // state hasn't caught up to yet.
     const getCurrentBodyHtml = () => quillRef.current?.getEditor?.()?.root.innerHTML ?? body;
 
+    // The {Signature} special parameter resolves per-email from the rendered
+    // From address, so it can't be precomputed in the student data cache.
+    const getMissingSignatureFroms = (students) => {
+        if (!isParameterUsedInTemplate('Signature')) return [];
+        const fromTemplate = fromPills[0] || '';
+        const data = (students && students.length) ? students : studentDataCache;
+        const froms = new Set();
+        if (data && data.length) {
+            data.forEach(student => {
+                const from = renderTemplate(fromTemplate, student);
+                if (from && from.trim()) froms.add(from.trim());
+            });
+        } else if (fromTemplate.trim()) {
+            froms.add(fromTemplate.trim());
+        }
+        return [...froms].filter(from => !findSignature(signatures, from));
+    };
+
     const generatePayload = (bodyHtml = body) => {
         const fromTemplate = fromPills[0] || '';
         // Strip parameter backgrounds from body before rendering
         const cleanBodyHtml = stripParameterBackgrounds(bodyHtml);
 
-        const emails = studentDataCache.map(student => ({
-            from: renderTemplate(fromTemplate, student),
-            to: student.StudentEmail || '',
-            cc: renderCCTemplate(ccPills, student),
-            subject: renderTemplate(subject, student),
-            body: renderTemplate(cleanBodyHtml, student)
-        })).filter(email => email.to && email.from);
+        const emails = studentDataCache.map(student => {
+            const from = renderTemplate(fromTemplate, student);
+            // Inject the From-specific signature so {Signature} renders correctly.
+            const studentWithSignature = { ...student, Signature: findSignature(signatures, from) };
+            return {
+                from,
+                to: student.StudentEmail || '',
+                cc: renderCCTemplate(ccPills, studentWithSignature),
+                subject: renderTemplate(subject, studentWithSignature),
+                body: renderTemplate(cleanBodyHtml, studentWithSignature)
+            };
+        }).filter(email => email.to && email.from);
 
         // Calculate sender breakdown
         const senderCounts = emails.reduce((acc, email) => {
@@ -1073,6 +1127,12 @@ export default function PersonalizedEmail({ user, onReady }) {
 
         if (payload.emails.length === 0) {
             setStatus('No students with valid "To" and "From" email addresses found.');
+            return;
+        }
+
+        const missingSignatures = getMissingSignatureFroms(studentDataCache);
+        if (missingSignatures.length > 0) {
+            setStatus(`No signature set for: ${missingSignatures.join(', ')}. Add one with the pencil icon next to "Special Parameters" before sending.`);
             return;
         }
 
@@ -1210,6 +1270,14 @@ export default function PersonalizedEmail({ user, onReady }) {
         const cleanBodyHtml = stripParameterBackgrounds(currentBody);
         const testFromEmail = renderTemplate(fromTemplate, testStudent);
 
+        if (isParameterUsedInTemplate('Signature') && !findSignature(signatures, testFromEmail)) {
+            setStatus(`No signature set for ${testFromEmail || 'the From address'}. Add one with the pencil icon next to "Special Parameters" before sending.`);
+            return;
+        }
+
+        // Inject the From-specific signature so {Signature} renders in the test.
+        const testStudentWithSignature = { ...testStudent, Signature: findSignature(signatures, testFromEmail) };
+
         const testPayload = {
             byName: user || '',
             byEmail: userEmail || '',
@@ -1219,8 +1287,8 @@ export default function PersonalizedEmail({ user, onReady }) {
                 from: testFromEmail,
                 to: userEmail, // Always send to the logged-in user
                 cc: '', // Don't CC anyone on test emails
-                subject: `[TEST] ${renderTemplate(subject, testStudent)}`,
-                body: renderTemplate(cleanBodyHtml, testStudent)
+                subject: `[TEST] ${renderTemplate(subject, testStudentWithSignature)}`,
+                body: renderTemplate(cleanBodyHtml, testStudentWithSignature)
             }]
         };
 
@@ -1487,7 +1555,20 @@ export default function PersonalizedEmail({ user, onReady }) {
 
                             {specialParameters.length > 0 && (
                                 <div className="mt-3">
-                                    <label className="block text-xs font-medium text-gray-600 mb-2">Special Parameters</label>
+                                    <div className="flex items-center gap-1 mb-2">
+                                        <label className="text-xs font-medium text-gray-600">Special Parameters</label>
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowSignatureModal(true)}
+                                            aria-label="Manage signatures"
+                                            title="Manage signatures for the {Signature} parameter"
+                                            className="p-0.5 text-gray-400 hover:text-blue-600"
+                                        >
+                                            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                                            </svg>
+                                        </button>
+                                    </div>
                                     <div className="flex flex-wrap gap-2">
                                         {specialParameters.map(param => renderParameterButton(param))}
                                     </div>
@@ -1617,6 +1698,7 @@ export default function PersonalizedEmail({ user, onReady }) {
                 ccRecipients={ccPills}
                 subjectTemplate={subject}
                 bodyTemplate={body}
+                signatures={signatures}
             />
 
             <TemplatesModal
@@ -1643,6 +1725,14 @@ export default function PersonalizedEmail({ user, onReady }) {
                 onClose={() => setShowCustomParamModal(false)}
                 customParameters={customParameters}
                 onSave={saveCustomParameters}
+            />
+
+            <SignatureModal
+                isOpen={showSignatureModal}
+                onClose={() => setShowSignatureModal(false)}
+                signatures={signatures}
+                onSave={saveSignatures}
+                currentFrom={fromPills[0] || ''}
             />
 
             <RecipientModal

--- a/react/src/components/personalizedEmail/modals/ExampleModal.jsx
+++ b/react/src/components/personalizedEmail/modals/ExampleModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { renderTemplate, renderCCTemplate } from '../utils/helpers';
+import { renderTemplate, renderCCTemplate, findSignature } from '../utils/helpers';
 
-export default function ExampleModal({ isOpen, onClose, studentData, fromTemplate, ccRecipients, subjectTemplate, bodyTemplate }) {
+export default function ExampleModal({ isOpen, onClose, studentData, fromTemplate, ccRecipients, subjectTemplate, bodyTemplate, signatures }) {
     const [currentIndex, setCurrentIndex] = useState(0);
     const [showSearch, setShowSearch] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
@@ -20,10 +20,12 @@ export default function ExampleModal({ isOpen, onClose, studentData, fromTemplat
 
     const student = studentData[currentIndex];
     const from = renderTemplate(fromTemplate, student);
+    // Inject the From-specific signature so {Signature} previews correctly.
+    const studentWithSignature = { ...student, Signature: findSignature(signatures, from) };
     const to = student.StudentEmail || '[No Email]';
-    const cc = renderCCTemplate(ccRecipients, student);
-    const subject = renderTemplate(subjectTemplate, student);
-    const body = renderTemplate(bodyTemplate, student);
+    const cc = renderCCTemplate(ccRecipients, studentWithSignature);
+    const subject = renderTemplate(subjectTemplate, studentWithSignature);
+    const body = renderTemplate(bodyTemplate, studentWithSignature);
 
     const handlePrevious = () => {
         if (currentIndex > 0) setCurrentIndex(currentIndex - 1);

--- a/react/src/components/personalizedEmail/modals/SignatureModal.jsx
+++ b/react/src/components/personalizedEmail/modals/SignatureModal.jsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
+import { QUILL_EDITOR_CONFIG } from '../utils/constants';
+import { normalizeEmailKey } from '../utils/helpers';
+import { compressImagesInHtml } from '../utils/imageCompression';
+
+// Manages the per-From-address signatures that power the {Signature} special
+// parameter. Each entry maps a From email to a rich-text signature; at send
+// time {Signature} resolves to the signature assigned to that email's From.
+export default function SignatureModal({ isOpen, onClose, signatures, onSave, currentFrom }) {
+    const [entries, setEntries] = useState([]);
+    const [saveStatus, setSaveStatus] = useState('');
+
+    useEffect(() => {
+        if (isOpen) {
+            // Work on a copy so Cancel discards unsaved edits.
+            const copy = (signatures || []).map(s => ({ email: s.email || '', signature: s.signature || '' }));
+            // Offer the current From address as a starter row when nothing is set up yet.
+            if (copy.length === 0 && currentFrom && currentFrom.trim()) {
+                copy.push({ email: currentFrom.trim(), signature: '' });
+            }
+            setEntries(copy);
+            setSaveStatus('');
+        }
+    }, [isOpen, signatures, currentFrom]);
+
+    const handleEntryChange = (index, field, value) => {
+        setEntries(prev => prev.map((entry, i) => (i === index ? { ...entry, [field]: value } : entry)));
+    };
+
+    const handleAddEntry = () => {
+        setEntries(prev => [...prev, { email: '', signature: '' }]);
+    };
+
+    const handleRemoveEntry = (index) => {
+        setEntries(prev => prev.filter((_, i) => i !== index));
+    };
+
+    const handleSave = async () => {
+        const base = entries
+            .map(e => ({ email: (e.email || '').trim(), signature: e.signature || '' }))
+            .filter(e => e.email);
+
+        // Block duplicate From addresses (same normalized email).
+        const keys = base.map(e => normalizeEmailKey(e.email));
+        if (new Set(keys).size !== keys.length) {
+            setSaveStatus('Two signatures use the same From address. Remove the duplicate.');
+            return;
+        }
+
+        setSaveStatus('Saving…');
+        // Compress oversized images so a signature (repeated across every
+        // recipient) doesn't bloat the email payload.
+        const cleaned = await Promise.all(
+            base.map(async (e) => ({ email: e.email, signature: await compressImagesInHtml(e.signature) }))
+        );
+
+        await onSave(cleaned);
+        setSaveStatus('Signatures saved!');
+        setTimeout(() => {
+            setSaveStatus('');
+            onClose();
+        }, 1000);
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-start justify-center z-50 overflow-y-auto p-4">
+            <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-2xl my-8 max-h-[calc(100vh-4rem)] overflow-y-auto">
+                <div className="flex justify-between items-center mb-2">
+                    <h3 className="text-lg font-semibold text-gray-800">Email Signatures</h3>
+                    <button onClick={onClose} className="text-gray-400 hover:text-gray-600" aria-label="Close">
+                        <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+                <p className="text-xs text-gray-500 mb-4">
+                    Assign a signature to each From address. Insert <span className="font-mono text-orange-700">{'{Signature}'}</span> in
+                    your email and it will be replaced with the signature for whichever From address is used. Emails can&apos;t be sent
+                    from a From address that has no signature.
+                </p>
+
+                <div className="space-y-4">
+                    {entries.length === 0 ? (
+                        <p className="text-center text-gray-500 text-sm py-4">No signatures yet. Add one below.</p>
+                    ) : (
+                        entries.map((entry, index) => (
+                            <div key={index} className="border border-gray-200 rounded-md p-3 bg-gray-50">
+                                <div className="flex items-center justify-between mb-2">
+                                    <span className="text-xs font-medium text-gray-600">Signature {index + 1}</span>
+                                    <button
+                                        onClick={() => handleRemoveEntry(index)}
+                                        aria-label={`Remove signature ${index + 1}`}
+                                        title="Remove"
+                                        className="text-red-500 hover:text-red-700 text-xl leading-none"
+                                    >
+                                        ×
+                                    </button>
+                                </div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">From address</label>
+                                <input
+                                    type="text"
+                                    value={entry.email}
+                                    onChange={(e) => handleEntryChange(index, 'email', e.target.value)}
+                                    className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm bg-white"
+                                    placeholder="e.g., advisor@school.edu"
+                                />
+                                <label className="block text-sm font-medium text-gray-700 mt-3 mb-1">Signature</label>
+                                <div className="bg-white rounded-md">
+                                    <ReactQuill
+                                        theme="snow"
+                                        value={entry.signature}
+                                        onChange={(value) => handleEntryChange(index, 'signature', value)}
+                                        modules={QUILL_EDITOR_CONFIG.modules}
+                                        placeholder="Your signature (formatting and pasted images supported)..."
+                                    />
+                                </div>
+                            </div>
+                        ))
+                    )}
+                </div>
+
+                <button
+                    onClick={handleAddEntry}
+                    className="mt-3 text-sm text-blue-600 hover:underline"
+                >
+                    + Add Signature
+                </button>
+
+                <p className="text-xs mt-2 h-4 text-center" style={{ color: saveStatus.includes('saved') ? '#16a34a' : '#dc2626' }}>
+                    {saveStatus}
+                </p>
+
+                <div className="flex justify-end gap-2 mt-4 border-t pt-4">
+                    <button
+                        onClick={onClose}
+                        className="px-3 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 text-sm"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        onClick={handleSave}
+                        className="px-3 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm"
+                    >
+                        Save
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react/src/components/personalizedEmail/utils/__tests__/helpers.test.js
+++ b/react/src/components/personalizedEmail/utils/__tests__/helpers.test.js
@@ -8,6 +8,8 @@ import {
     evaluateMapping,
     renderTemplate,
     renderCCTemplate,
+    normalizeEmailKey,
+    findSignature,
 } from '../helpers.js';
 
 describe('getTodaysLdaSheetName', () => {
@@ -280,5 +282,46 @@ describe('renderCCTemplate', () => {
         // Single recipient still gets template substitution
         expect(renderCCTemplate(['{name}@x.com'], { name: 'ada' }))
             .toBe('ada@x.com');
+    });
+});
+
+describe('normalizeEmailKey', () => {
+    it('lowercases and trims', () => {
+        expect(normalizeEmailKey('  Advisor@School.EDU ')).toBe('advisor@school.edu');
+    });
+
+    it('extracts the email from "Name <email>" form', () => {
+        expect(normalizeEmailKey('Jane Doe <Jane.Doe@School.edu>')).toBe('jane.doe@school.edu');
+    });
+
+    it('returns empty string for falsy input', () => {
+        expect(normalizeEmailKey('')).toBe('');
+        expect(normalizeEmailKey(null)).toBe('');
+        expect(normalizeEmailKey(undefined)).toBe('');
+    });
+});
+
+describe('findSignature', () => {
+    const signatures = [
+        { email: 'advisor@school.edu', signature: '<p>Best, Advisor</p>' },
+        { email: 'Dean <dean@school.edu>', signature: '<p>Regards, Dean</p>' },
+    ];
+
+    it('matches case-insensitively', () => {
+        expect(findSignature(signatures, 'ADVISOR@school.edu')).toBe('<p>Best, Advisor</p>');
+    });
+
+    it('matches a plain From against a "Name <email>" entry', () => {
+        expect(findSignature(signatures, 'dean@school.edu')).toBe('<p>Regards, Dean</p>');
+    });
+
+    it('returns empty string when no signature is assigned', () => {
+        expect(findSignature(signatures, 'nobody@school.edu')).toBe('');
+    });
+
+    it('handles empty / missing inputs', () => {
+        expect(findSignature([], 'advisor@school.edu')).toBe('');
+        expect(findSignature(null, 'advisor@school.edu')).toBe('');
+        expect(findSignature(signatures, '')).toBe('');
     });
 });

--- a/react/src/components/personalizedEmail/utils/constants.js
+++ b/react/src/components/personalizedEmail/utils/constants.js
@@ -17,13 +17,15 @@ import {
 
 export const EMAIL_TEMPLATES_KEY = "emailTemplates";
 export const CUSTOM_PARAMS_KEY = "customEmailParameters";
+export const EMAIL_SIGNATURES_KEY = "emailSignatures";
 export const LAST_EMAIL_SENT_KEY = "lastEmailSent";
 
 // Standard, built-in parameters that are always available
 export const standardParameters = ['FirstName', 'LastName', 'StudentEmail', 'PersonalEmail', 'Grade', 'DaysOut', 'Assigned'];
 
-// Special built-in parameters (more advanced, dynamically generated)
-export const specialParameters = ['MissingAssignmentsList', 'DaysLeft', 'Salutation'];
+// Special built-in parameters (more advanced, dynamically generated).
+// Signature resolves per-email from the From address (see emailSignatures).
+export const specialParameters = ['MissingAssignmentsList', 'DaysLeft', 'Salutation', 'Signature'];
 
 // Configuration for the main rich text editor
 export const QUILL_EDITOR_CONFIG = {

--- a/react/src/components/personalizedEmail/utils/helpers.js
+++ b/react/src/components/personalizedEmail/utils/helpers.js
@@ -115,6 +115,26 @@ export const renderCCTemplate = (recipients, data) => {
     return recipients.map(recipient => renderTemplate(recipient, data)).join(';');
 };
 
+// Normalizes a From value to a comparable key. Lowercases/trims and, when the
+// value is in "Name <email>" form, uses just the email so signatures match
+// regardless of display name.
+export const normalizeEmailKey = (value) => {
+    if (!value) return '';
+    const str = String(value).trim().toLowerCase();
+    const match = str.match(/<([^>]+)>/);
+    return (match ? match[1] : str).trim();
+};
+
+// Looks up the signature HTML assigned to a given From address.
+// `signatures` is an array of { email, signature }. Returns '' if none.
+export const findSignature = (signatures, fromValue) => {
+    if (!Array.isArray(signatures) || signatures.length === 0) return '';
+    const key = normalizeEmailKey(fromValue);
+    if (!key) return '';
+    const match = signatures.find(s => normalizeEmailKey(s.email) === key);
+    return match ? (match.signature || '') : '';
+};
+
 /**
  * Pre-loads the "Missing Assignments" sheet and builds a lookup map
  * of Grade Book URL → HTML assignment list.  Call once before the

--- a/react/src/components/personalizedEmail/utils/imageCompression.js
+++ b/react/src/components/personalizedEmail/utils/imageCompression.js
@@ -43,6 +43,42 @@ export function formatBytes(bytes) {
 }
 
 /**
+ * Compress any oversized data-URI images inside an HTML string and return the
+ * updated HTML. Used for content authored outside the main editor (e.g. saved
+ * signatures), which would otherwise embed full-size images that repeat across
+ * every recipient and bloat the payload. Non-image and remote sources are left
+ * untouched. Falls back to the original HTML if parsing/compression isn't
+ * possible (e.g. outside a browser).
+ * @param {string} html
+ * @returns {Promise<string>}
+ */
+export async function compressImagesInHtml(html) {
+    if (!html || typeof html !== 'string' || !html.includes('<img')) return html;
+    if (typeof DOMParser === 'undefined') return html;
+
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const imgs = Array.from(doc.querySelectorAll('img'));
+    let changed = false;
+
+    await Promise.all(imgs.map(async (img) => {
+        const src = img.getAttribute('src') || '';
+        if (src.startsWith('data:image') && dataUriByteLength(src) > IMAGE_COMPRESS_THRESHOLD_BYTES) {
+            try {
+                const compressed = await compressDataUriImage(src);
+                if (compressed) {
+                    img.setAttribute('src', compressed);
+                    changed = true;
+                }
+            } catch {
+                // Keep the original image if compression fails.
+            }
+        }
+    }));
+
+    return changed ? doc.body.innerHTML : html;
+}
+
+/**
  * Downscale + re-encode a base64 image data-URI so it's small enough to embed in
  * the email payload. Resolves to a new JPEG data-URI, or rejects if the image
  * can't be loaded/encoded (e.g. a tainted or unsupported source).


### PR DESCRIPTION
Adds a Signature special parameter whose value is resolved per email from the From address in use, plus a modal to manage signatures (opened by a pencil icon next to "Special Parameters", mirroring custom parameters).

- Signatures are stored in workbook settings (emailSignatures) as [{ email, signature }] and managed in a new SignatureModal (rich-text, add/remove/save). Images pasted into a signature are compressed on save so a signature repeated across recipients can't bloat the payload.
- {Signature} resolves at render time (send, test, and Example preview) to the signature assigned to that email's rendered From address, matched case-insensitively and tolerant of "Name <email>" form.
- Sending is blocked (with a clear message) when {Signature} is used and any From address in the batch has no signature assigned.
- New helpers normalizeEmailKey + findSignature, with unit tests.


Claude-Session: https://claude.ai/code/session_018JUeE6iqJJ9QRzZoERGD7U