### PR TITLE
Autocomplete From/CC emails from registered workbook users

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -17,6 +17,7 @@ import RecipientModal from './modals/RecipientModal';
 import ConfirmSendModal from './modals/ConfirmSendModal';
 import SuccessModal from './modals/SuccessModal';
 import { getWorkbookSettings } from '../utility/getSettings';
+import { getWorkbookUsers } from '../../services/workbookUsers';
 import { MASTER_LIST_SHEET, HISTORY_SHEET } from '../../../../shared/constants.js';
 
 export default function PersonalizedEmail({ user, onReady }) {
@@ -40,6 +41,8 @@ export default function PersonalizedEmail({ user, onReady }) {
     const [cachedSpecialParams, setCachedSpecialParams] = useState([]);
     const [customParameters, setCustomParameters] = useState([]);
     const [signatures, setSignatures] = useState([]);
+    // Email suggestions for the From/CC fields, sourced from registered workbook users.
+    const [addressSuggestions, setAddressSuggestions] = useState([]);
     const [recipientSelection, setRecipientSelection] = useState({
         type: 'lda',
         customSheetName: '',
@@ -130,6 +133,25 @@ export default function PersonalizedEmail({ user, onReady }) {
     useEffect(() => () => {
         if (imageNoticeTimerRef.current) clearTimeout(imageNoticeTimerRef.current);
         if (compressImagesTimerRef.current) clearTimeout(compressImagesTimerRef.current);
+    }, []);
+
+    // Load registered workbook users once for From/CC email autocomplete.
+    useEffect(() => {
+        try {
+            const seen = new Set();
+            const suggestions = [];
+            (getWorkbookUsers() || []).forEach(u => {
+                const email = (u.email || '').trim();
+                if (!email) return;
+                const key = email.toLowerCase();
+                if (seen.has(key)) return;
+                seen.add(key);
+                suggestions.push({ name: (u.name || '').trim(), email });
+            });
+            setAddressSuggestions(suggestions);
+        } catch (error) {
+            console.error('Error loading workbook users for autocomplete:', error);
+        }
     }, []);
 
     // Setup automatic parameter highlighting
@@ -1445,6 +1467,7 @@ export default function PersonalizedEmail({ user, onReady }) {
                         readOnly={mode === 'individual'}
                         noWrap={true}
                         getPillColor={getParameterColor}
+                        suggestions={addressSuggestions}
                     />
                 </div>
 
@@ -1485,6 +1508,7 @@ export default function PersonalizedEmail({ user, onReady }) {
                             onFocus={() => setLastFocusedInput('cc')}
                             noWrap={true}
                             getPillColor={getParameterColor}
+                            suggestions={addressSuggestions}
                         />
                     </div>
                 )}

--- a/react/src/components/personalizedEmail/components/PillInput.jsx
+++ b/react/src/components/personalizedEmail/components/PillInput.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 
 export default function PillInput({
     pills,
@@ -8,19 +8,42 @@ export default function PillInput({
     onFocus,
     readOnly = false,
     noWrap = false,
-    getPillColor
+    getPillColor,
+    suggestions = []
 }) {
     const inputRef = useRef(null);
     const containerRef = useRef(null);
+    const [inputValue, setInputValue] = useState('');
+    const [showSuggestions, setShowSuggestions] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(-1);
+
+    // Accept either { name, email } objects or plain email strings.
+    const normalizedSuggestions = (suggestions || [])
+        .map(s => (typeof s === 'string' ? { name: '', email: s } : { name: s.name || '', email: s.email || '' }))
+        .filter(s => s.email);
+
+    const pillSet = new Set(pills.map(p => p.toLowerCase()));
+    const query = inputValue.trim().toLowerCase();
+    // Match on email OR name, so typing someone's name surfaces their email.
+    const matches = query
+        ? normalizedSuggestions
+            .filter(s => !pillSet.has(s.email.toLowerCase()))
+            .filter(s => s.email.toLowerCase().includes(query) || s.name.toLowerCase().includes(query))
+            .slice(0, 8)
+        : [];
+    const isOpen = showSuggestions && matches.length > 0;
 
     const addPill = (text) => {
         if (!text || !text.trim()) return;
-
+        const value = text.trim();
         if (singleValue) {
-            onPillsChange([text.trim()]);
-        } else {
-            onPillsChange([...pills, text.trim()]);
+            onPillsChange([value]);
+        } else if (!pills.some(p => p.toLowerCase() === value.toLowerCase())) {
+            onPillsChange([...pills, value]);
         }
+        setInputValue('');
+        setActiveIndex(-1);
+        setShowSuggestions(false);
     };
 
     const removePill = (index) => {
@@ -29,18 +52,53 @@ export default function PillInput({
     };
 
     const handleKeyDown = (e) => {
+        if (isOpen && e.key === 'ArrowDown') {
+            e.preventDefault();
+            setActiveIndex(i => Math.min(i + 1, matches.length - 1));
+            return;
+        }
+        if (isOpen && e.key === 'ArrowUp') {
+            e.preventDefault();
+            setActiveIndex(i => Math.max(i - 1, 0));
+            return;
+        }
+        if (e.key === 'Escape') {
+            setShowSuggestions(false);
+            setActiveIndex(-1);
+            return;
+        }
+
         if (e.key === ',' || e.key === 'Enter' || e.key === ';') {
             e.preventDefault();
-            addPill(inputRef.current.value);
-            inputRef.current.value = '';
-        } else if (e.key === 'Backspace' && inputRef.current.value === '' && pills.length > 0) {
+            // If a suggestion is highlighted, take it; otherwise use what was typed.
+            if (isOpen && activeIndex >= 0 && matches[activeIndex]) {
+                addPill(matches[activeIndex].email);
+            } else {
+                addPill(inputValue);
+            }
+        } else if (e.key === 'Backspace' && inputValue === '' && pills.length > 0) {
             removePill(pills.length - 1);
         }
     };
 
+    const handleChange = (e) => {
+        setInputValue(e.target.value);
+        setShowSuggestions(true);
+        setActiveIndex(-1);
+    };
+
     const handleBlur = () => {
-        addPill(inputRef.current.value);
-        inputRef.current.value = '';
+        // A suggestion click uses onMouseDown (preventDefault) so it runs before
+        // this; clicking elsewhere commits whatever was typed, matching the old
+        // behavior.
+        if (inputValue.trim()) addPill(inputValue);
+        setShowSuggestions(false);
+        setActiveIndex(-1);
+    };
+
+    const handleFocus = (e) => {
+        if (onFocus) onFocus(e);
+        setShowSuggestions(true);
     };
 
     const handleContainerClick = () => {
@@ -48,55 +106,94 @@ export default function PillInput({
     };
 
     return (
-        <div
-            ref={containerRef}
-            onClick={readOnly ? undefined : handleContainerClick}
-            className={`flex items-center gap-1.5 p-1.5 border border-gray-300 rounded-md ${
-                noWrap ? 'overflow-x-auto' : 'flex-wrap'
-            } ${readOnly ? 'bg-gray-100 cursor-default' : 'bg-white cursor-text'}`}
-        >
-            {pills.map((pill, index) => {
-                const isParam = pill.startsWith('{') && pill.endsWith('}');
-                const customColor = isParam && getPillColor ? getPillColor(pill.slice(1, -1)) : null;
-                return (
-                    <span
-                        key={index}
-                        style={customColor ? { backgroundColor: customColor.background, color: customColor.color } : undefined}
-                        className={`flex items-center rounded-full px-2 py-0.5 text-sm ${
-                            customColor
-                                ? ''
-                                : isParam
-                                    ? 'bg-blue-100 text-blue-800'
-                                    : 'bg-gray-200 text-gray-700'
+        <div className="relative" ref={containerRef}>
+            <div
+                onClick={readOnly ? undefined : handleContainerClick}
+                className={`flex items-center gap-1.5 p-1.5 border border-gray-300 rounded-md ${
+                    noWrap ? 'overflow-x-auto' : 'flex-wrap'
+                } ${readOnly ? 'bg-gray-100 cursor-default' : 'bg-white cursor-text'}`}
+            >
+                {pills.map((pill, index) => {
+                    const isParam = pill.startsWith('{') && pill.endsWith('}');
+                    const customColor = isParam && getPillColor ? getPillColor(pill.slice(1, -1)) : null;
+                    return (
+                        <span
+                            key={index}
+                            style={customColor ? { backgroundColor: customColor.background, color: customColor.color } : undefined}
+                            className={`flex items-center rounded-full px-2 py-0.5 text-sm ${
+                                customColor
+                                    ? ''
+                                    : isParam
+                                        ? 'bg-blue-100 text-blue-800'
+                                        : 'bg-gray-200 text-gray-700'
+                            }`}
+                        >
+                            {pill}
+                            {!readOnly && (
+                                <span
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        removePill(index);
+                                    }}
+                                    className="ml-1.5 cursor-pointer font-bold hover:text-red-600"
+                                >
+                                    ×
+                                </span>
+                            )}
+                        </span>
+                    );
+                })}
+                {!readOnly && (
+                    <input
+                        ref={inputRef}
+                        type="text"
+                        value={inputValue}
+                        className={`flex-grow border-none outline-none p-1 bg-transparent ${
+                            noWrap ? 'min-w-[80px]' : 'min-w-[120px]'
                         }`}
-                    >
-                        {pill}
-                        {!readOnly && (
-                            <span
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    removePill(index);
-                                }}
-                                className="ml-1.5 cursor-pointer font-bold hover:text-red-600"
-                            >
-                                ×
-                            </span>
-                        )}
-                    </span>
-                );
-            })}
-            {!readOnly && (
-                <input
-                    ref={inputRef}
-                    type="text"
-                    className={`flex-grow border-none outline-none p-1 bg-transparent ${
-                        noWrap ? 'min-w-[80px]' : 'min-w-[120px]'
-                    }`}
-                    placeholder={pills.length === 0 ? placeholder : ''}
-                    onKeyDown={handleKeyDown}
-                    onBlur={handleBlur}
-                    onFocus={onFocus}
-                />
+                        placeholder={pills.length === 0 ? placeholder : ''}
+                        onChange={handleChange}
+                        onKeyDown={handleKeyDown}
+                        onBlur={handleBlur}
+                        onFocus={handleFocus}
+                        autoComplete="off"
+                        role="combobox"
+                        aria-expanded={isOpen}
+                        aria-autocomplete="list"
+                    />
+                )}
+            </div>
+
+            {isOpen && (
+                <ul
+                    className="absolute left-0 right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-md shadow-lg max-h-48 overflow-y-auto py-1"
+                    role="listbox"
+                >
+                    {matches.map((s, idx) => (
+                        <li
+                            key={s.email}
+                            role="option"
+                            aria-selected={idx === activeIndex}
+                            // Keep focus so onBlur doesn't fire before the click selects.
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                                addPill(s.email);
+                                inputRef.current?.focus();
+                            }}
+                            onMouseEnter={() => setActiveIndex(idx)}
+                            className={`px-3 py-1.5 cursor-pointer ${idx === activeIndex ? 'bg-blue-50' : 'hover:bg-gray-100'}`}
+                        >
+                            {s.name
+                                ? (
+                                    <div className="flex flex-col leading-tight">
+                                        <span className="text-sm text-gray-800">{s.name}</span>
+                                        <span className="text-xs text-gray-500">{s.email}</span>
+                                    </div>
+                                )
+                                : <span className="text-sm text-gray-800">{s.email}</span>}
+                        </li>
+                    ))}
+                </ul>
             )}
         </div>
     );


### PR DESCRIPTION
Typing in the From or CC field now suggests registered workbook users. Matching is by email OR name — so typing someone's name surfaces their email — and selecting a suggestion inserts the email address.

- PillInput: controlled input with a suggestion dropdown (keyboard up/down/enter, click, Escape; already-added emails are excluded). The dropdown sits outside the field's scroll box so it isn't clipped.
- PersonalizedEmail: loads getWorkbookUsers() once into deduped { name, email } suggestions and passes them to the From and CC inputs.


Claude-Session: https://claude.ai/code/session_018JUeE6iqJJ9QRzZoERGD7U