### PR TITLE
Autocomplete the From address in the Signature modal

### DIFF
--- a/react/src/components/personalizedEmail/PersonalizedEmail.jsx
+++ b/react/src/components/personalizedEmail/PersonalizedEmail.jsx
@@ -1757,6 +1757,7 @@ export default function PersonalizedEmail({ user, onReady }) {
                 signatures={signatures}
                 onSave={saveSignatures}
                 currentFrom={fromPills[0] || ''}
+                suggestions={addressSuggestions}
             />
 
             <RecipientModal

--- a/react/src/components/personalizedEmail/components/EmailAutocompleteInput.jsx
+++ b/react/src/components/personalizedEmail/components/EmailAutocompleteInput.jsx
@@ -1,0 +1,103 @@
+import React, { useRef, useState } from 'react';
+
+// A single-value text input with an email-suggestion dropdown. Matches on email
+// OR name (typing a name surfaces the email) and writes the selected email back
+// through onChange. Used where a plain email field needs autocomplete (e.g. the
+// signature modal's From address) rather than the pill-based PillInput.
+export default function EmailAutocompleteInput({
+    value,
+    onChange,
+    suggestions = [],
+    placeholder,
+    className,
+    id,
+}) {
+    const inputRef = useRef(null);
+    const [showSuggestions, setShowSuggestions] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(-1);
+
+    const normalized = (suggestions || [])
+        .map(s => (typeof s === 'string' ? { name: '', email: s } : { name: s.name || '', email: s.email || '' }))
+        .filter(s => s.email);
+
+    const query = (value || '').trim().toLowerCase();
+    const matches = query
+        ? normalized
+            .filter(s => s.email.toLowerCase() !== query) // already entered exactly
+            .filter(s => s.email.toLowerCase().includes(query) || s.name.toLowerCase().includes(query))
+            .slice(0, 8)
+        : [];
+    const isOpen = showSuggestions && matches.length > 0;
+
+    const select = (email) => {
+        onChange(email);
+        setShowSuggestions(false);
+        setActiveIndex(-1);
+        inputRef.current?.focus();
+    };
+
+    const handleKeyDown = (e) => {
+        if (!isOpen) return;
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setActiveIndex(i => Math.min(i + 1, matches.length - 1));
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setActiveIndex(i => Math.max(i - 1, 0));
+        } else if (e.key === 'Enter' && activeIndex >= 0 && matches[activeIndex]) {
+            e.preventDefault();
+            select(matches[activeIndex].email);
+        } else if (e.key === 'Escape') {
+            setShowSuggestions(false);
+            setActiveIndex(-1);
+        }
+    };
+
+    return (
+        <div className="relative">
+            <input
+                ref={inputRef}
+                id={id}
+                type="text"
+                value={value}
+                onChange={(e) => { onChange(e.target.value); setShowSuggestions(true); setActiveIndex(-1); }}
+                onFocus={() => setShowSuggestions(true)}
+                onBlur={() => { setShowSuggestions(false); setActiveIndex(-1); }}
+                onKeyDown={handleKeyDown}
+                placeholder={placeholder}
+                className={className}
+                autoComplete="off"
+                role="combobox"
+                aria-expanded={isOpen}
+                aria-autocomplete="list"
+            />
+            {isOpen && (
+                <ul
+                    className="absolute left-0 right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-md shadow-lg max-h-48 overflow-y-auto py-1"
+                    role="listbox"
+                >
+                    {matches.map((s, idx) => (
+                        <li
+                            key={s.email}
+                            role="option"
+                            aria-selected={idx === activeIndex}
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => select(s.email)}
+                            onMouseEnter={() => setActiveIndex(idx)}
+                            className={`px-3 py-1.5 cursor-pointer ${idx === activeIndex ? 'bg-blue-50' : 'hover:bg-gray-100'}`}
+                        >
+                            {s.name
+                                ? (
+                                    <div className="flex flex-col leading-tight">
+                                        <span className="text-sm text-gray-800">{s.name}</span>
+                                        <span className="text-xs text-gray-500">{s.email}</span>
+                                    </div>
+                                )
+                                : <span className="text-sm text-gray-800">{s.email}</span>}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/react/src/components/personalizedEmail/modals/SignatureModal.jsx
+++ b/react/src/components/personalizedEmail/modals/SignatureModal.jsx
@@ -4,11 +4,12 @@ import 'react-quill-new/dist/quill.snow.css';
 import { QUILL_EDITOR_CONFIG } from '../utils/constants';
 import { normalizeEmailKey } from '../utils/helpers';
 import { compressImagesInHtml } from '../utils/imageCompression';
+import EmailAutocompleteInput from '../components/EmailAutocompleteInput';
 
 // Manages the per-From-address signatures that power the {Signature} special
 // parameter. Each entry maps a From email to a rich-text signature; at send
 // time {Signature} resolves to the signature assigned to that email's From.
-export default function SignatureModal({ isOpen, onClose, signatures, onSave, currentFrom }) {
+export default function SignatureModal({ isOpen, onClose, signatures, onSave, currentFrom, suggestions = [] }) {
     const [entries, setEntries] = useState([]);
     const [saveStatus, setSaveStatus] = useState('');
 
@@ -101,12 +102,12 @@ export default function SignatureModal({ isOpen, onClose, signatures, onSave, cu
                                     </button>
                                 </div>
                                 <label className="block text-sm font-medium text-gray-700 mb-1">From address</label>
-                                <input
-                                    type="text"
+                                <EmailAutocompleteInput
                                     value={entry.email}
-                                    onChange={(e) => handleEntryChange(index, 'email', e.target.value)}
+                                    onChange={(value) => handleEntryChange(index, 'email', value)}
+                                    suggestions={suggestions}
+                                    placeholder="Type a name or email, e.g. advisor@school.edu"
                                     className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm bg-white"
-                                    placeholder="e.g., advisor@school.edu"
                                 />
                                 <label className="block text-sm font-medium text-gray-700 mt-3 mb-1">Signature</label>
                                 <div className="bg-white rounded-md">


### PR DESCRIPTION
The signature modal's From-address field now suggests registered workbook users as you type — matching by name or email and filling in the email — so assigning a signature to an address is faster.

- New EmailAutocompleteInput: a single-value text input with the same name/email suggestion dropdown as the From/CC pills, for plain text fields.
- SignatureModal uses it for the From address and accepts a suggestions prop.
- PersonalizedEmail passes the workbook-user suggestions through.


Claude-Session: https://claude.ai/code/session_018JUeE6iqJJ9QRzZoERGD7U