### PR TITLE
Prevent Outreach auto-highlight from clearing user-applied colors

### DIFF
--- a/react/src/components/studentView/StudentView.jsx
+++ b/react/src/components/studentView/StudentView.jsx
@@ -336,9 +336,11 @@ function StudentView({ onReady, user }) {
                 const tagString = match && tag ? `${tag}, Outreach` : 'Outreach';
                 // Highlight (or clear) the row from column A through the
                 // Outreach column, skipping the Assigned column so its own
-                // formatting is preserved.
+                // formatting is preserved. On a non-matching edit we only clear
+                // a row that's currently yellow (the Contacted highlight) so we
+                // don't accidentally wipe highlights applied in other colors.
                 const fillColor = match ? 'yellow' : null;
-                setRowSegmentFill(change.rowIndex, change.colIndex, fillColor, [ASSIGNED_ALIASES]);
+                setRowSegmentFill(change.rowIndex, change.colIndex, fillColor, [ASSIGNED_ALIASES], match ? {} : { clearOnlyIfColor: '#FFFF00' });
                 // Auto Outreach handler opts into dedupe: a single advisor edit can
                 // produce repeated change events, and co-editing advisors update the
                 // same cell during the day. Manual comments do NOT pass this flag.

--- a/react/src/components/utility/ExcelAPI.jsx
+++ b/react/src/components/utility/ExcelAPI.jsx
@@ -619,8 +619,15 @@ export async function clearRowFill(rowIndex, startCol, colCount) {
  * @param {string|null} color - Fill color (e.g. 'yellow'); pass null to clear
  * @param {string[][]} skipAliasGroups - Arrays of header aliases (e.g.
  *        [ASSIGNED_ALIASES]) — any matching column is left untouched
+ * @param {Object} [options]
+ * @param {string|null} [options.clearOnlyIfColor] - When clearing (color is
+ *        null), only clear a segment if its existing fill matches this color
+ *        (case-insensitive hex, e.g. '#FFFF00'). Segments with any other color
+ *        — or mixed colors — are left untouched. Prevents the Outreach
+ *        auto-highlight from wiping highlights applied in other colors.
  */
-export async function setRowSegmentFill(rowIndex, endColIdx, color, skipAliasGroups = []) {
+export async function setRowSegmentFill(rowIndex, endColIdx, color, skipAliasGroups = [], options = {}) {
+  const { clearOnlyIfColor = null } = options || {};
   if (typeof window.Excel === 'undefined') return;
   if (typeof rowIndex !== 'number' || typeof endColIdx !== 'number') return;
   if (rowIndex < 0 || endColIdx < 0) return;
@@ -657,12 +664,31 @@ export async function setRowSegmentFill(rowIndex, endColIdx, color, skipAliasGro
       }
       if (segStart <= endColIdx) segments.push([segStart, endColIdx - segStart + 1]);
 
-      for (const [start, count] of segments) {
-        const rng = sheet.getRangeByIndexes(rowIndex, start, 1, count);
-        if (color === null || color === undefined) {
-          rng.format.fill.clear();
-        } else {
-          rng.format.fill.color = color;
+      const clearing = (color === null || color === undefined);
+
+      if (clearing && clearOnlyIfColor) {
+        // Conditional clear: only wipe segments whose existing fill matches the
+        // target color. Load each segment's color first, then clear matches.
+        const target = String(clearOnlyIfColor).toLowerCase();
+        const ranges = segments.map(([start, count]) => {
+          const rng = sheet.getRangeByIndexes(rowIndex, start, 1, count);
+          rng.format.fill.load('color');
+          return rng;
+        });
+        await context.sync();
+        for (const rng of ranges) {
+          if (String(rng.format.fill.color).toLowerCase() === target) {
+            rng.format.fill.clear();
+          }
+        }
+      } else {
+        for (const [start, count] of segments) {
+          const rng = sheet.getRangeByIndexes(rowIndex, start, 1, count);
+          if (clearing) {
+            rng.format.fill.clear();
+          } else {
+            rng.format.fill.color = color;
+          }
         }
       }
       await context.sync();


### PR DESCRIPTION
## Summary

When the Outreach auto-highlight feature clears a row (on non-matching edits), it now only removes cells that are currently yellow (the Contacted highlight color), leaving highlights applied in other colors untouched. This prevents accidental data loss when users manually highlight rows in different colors.

## Changes

- **ExcelAPI.jsx**: Extended `setRowSegmentFill()` with an optional `clearOnlyIfColor` parameter
  - When clearing fill (`color === null`) and `clearOnlyIfColor` is set, the function now loads each segment's existing fill color and only clears those matching the target color (case-insensitive hex comparison)
  - Segments with different colors or mixed colors are left untouched
  - Refactored the fill-setting logic to handle conditional clearing separately from unconditional operations

- **StudentView.jsx**: Updated the Outreach auto-highlight handler to use the new conditional-clear feature
  - On non-matching edits (when clearing), passes `{ clearOnlyIfColor: '#FFFF00' }` to only remove yellow highlights
  - On matching edits (when applying yellow), passes an empty options object for normal behavior
  - Updated comment to explain the conditional-clear logic

## Implementation Details

The conditional-clear path uses `rng.format.fill.load('color')` followed by `context.sync()` to batch-load all segment colors before deciding which to clear. This avoids multiple round-trips to the Office runtime while preserving the ability to selectively clear based on existing fill state.

https://claude.ai/code/session_01BRDT37aexvFS3VeHBSqF7m