### PR TITLE
Persist emergency contacts in workbook settings by SyStudentId

### DIFF
--- a/react/src/components/studentView/Parts/EmergencyContactCard.jsx
+++ b/react/src/components/studentView/Parts/EmergencyContactCard.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { User, Phone, Heart, X } from 'lucide-react';
+
+// Card that displays a single saved emergency contact.
+// When `onRemove` is provided, a small delete button is shown.
+const EmergencyContactCard = ({ contact, onRemove }) => {
+  if (!contact) return null;
+
+  const { name, number, relationship } = contact;
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        border: '1px solid #fecaca',
+        background: '#fef2f2',
+        borderRadius: '0.75rem',
+        padding: '0.75rem 0.875rem'
+      }}
+    >
+      {onRemove && (
+        <button
+          type="button"
+          onClick={() => onRemove(contact)}
+          aria-label={`Remove ${name || 'emergency contact'}`}
+          title="Remove"
+          style={{
+            position: 'absolute',
+            top: 6,
+            right: 6,
+            width: 22,
+            height: 22,
+            borderRadius: '9999px',
+            border: 'none',
+            background: 'transparent',
+            color: '#b91c1c',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer'
+          }}
+        >
+          <X size={16} />
+        </button>
+      )}
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, paddingRight: 20 }}>
+        <User size={16} color="#b91c1c" style={{ flexShrink: 0 }} />
+        <span style={{ fontWeight: 700, color: '#1f2937', fontSize: 14 }}>
+          {name || 'Unnamed contact'}
+        </span>
+        {relationship && (
+          <span
+            style={{
+              marginLeft: 'auto',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 4,
+              fontSize: 11,
+              fontWeight: 600,
+              color: '#b91c1c',
+              background: '#fee2e2',
+              borderRadius: '9999px',
+              padding: '2px 8px'
+            }}
+          >
+            <Heart size={11} />
+            {relationship}
+          </span>
+        )}
+      </div>
+
+      {number && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Phone size={16} color="#6b7280" style={{ flexShrink: 0 }} />
+          <a
+            href={`tel:${number}`}
+            style={{ color: '#374151', fontSize: 14, textDecoration: 'none' }}
+          >
+            {number}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EmergencyContactCard;

--- a/react/src/components/studentView/Tabs/Details.jsx
+++ b/react/src/components/studentView/Tabs/Details.jsx
@@ -1,5 +1,5 @@
 // 2025-12-11 11:28 EST - Version 3.8.0 - Updated Program bolding: 'in'/'with' remain normal, text AFTER them is bolded
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   IdCardLanyard,
   Mail,
@@ -20,6 +20,12 @@ import callIcon from '../../../assets/icons/call-icon.png';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { formatExcelDate } from '../../utility/Conversion';
 import AddEmergencyContactModal from '../Modal/AddEmergencyContactModal';
+import EmergencyContactCard from '../Parts/EmergencyContactCard';
+import {
+  getEmergencyContacts,
+  addEmergencyContact,
+  removeEmergencyContact
+} from '../../../services/emergencyContacts';
 
 // A small reusable component for displaying a single detail item.
 const DetailItem = ({ label, value }) => {
@@ -284,17 +290,45 @@ function StudentDetails({ student }) {
   // State for the "Add Emergency Contact" modal
   const [showAddEmergencyModal, setShowAddEmergencyModal] = useState(false);
 
+  // Saved emergency contacts for this student, plus a delete/manage toggle.
+  const [emergencyContacts, setEmergencyContacts] = useState([]);
+  const [emergencyDeleteMode, setEmergencyDeleteMode] = useState(false);
+
+  // The SyStudentId (canonical ID) is the identifier we key contacts by.
+  const studentId = student && (student.ID ?? student.StudentNumber);
+
+  // Load saved emergency contacts whenever the viewed student changes.
+  useEffect(() => {
+    setEmergencyDeleteMode(false);
+    setEmergencyContacts(getEmergencyContacts(studentId));
+  }, [studentId]);
+
   const handlePrev = () => setPage((prev) => Math.max(0, prev - 1));
   const handleNext = () => setPage((prev) => Math.min(totalPages - 1, prev + 1));
 
   const toggleEmergency = () => setShowEmergency((prev) => !prev);
 
-  // Placeholder handlers for adding / removing emergency numbers (logic TBD)
   const handleAddEmergency = () => {
     setShowAddEmergencyModal(true);
   };
+
+  // The header trash button toggles a delete mode that reveals per-card removal.
   const handleRemoveEmergency = () => {
-    // TODO: wire up remove-emergency-number logic
+    setEmergencyDeleteMode((prev) => !prev);
+  };
+
+  const handleAddEmergencyContact = async (contact) => {
+    const updated = await addEmergencyContact(studentId, contact);
+    if (updated) setEmergencyContacts(updated);
+  };
+
+  const handleRemoveEmergencyContact = async (contact) => {
+    if (!contact || !contact.id) return;
+    const updated = await removeEmergencyContact(studentId, contact.id);
+    if (updated) {
+      setEmergencyContacts(updated);
+      if (updated.length === 0) setEmergencyDeleteMode(false);
+    }
   };
 
   // Helper to determine header text
@@ -351,11 +385,17 @@ function StudentDetails({ student }) {
                 <div className="relative">
                   <button
                     id="remove-emergency-button"
-                    className="bg-gray-500 text-white w-8 h-8 rounded-full shadow-lg flex items-center justify-center hover:bg-red-400 transition-colors"
+                    className={`text-white w-8 h-8 rounded-full shadow-lg flex items-center justify-center transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                      emergencyDeleteMode
+                        ? 'bg-red-400 hover:bg-red-500'
+                        : 'bg-gray-500 hover:bg-red-400'
+                    }`}
                     aria-label="Remove Emergency Number"
-                    title="Remove Emergency Number"
+                    title={emergencyDeleteMode ? 'Done removing' : 'Remove Emergency Number'}
                     type="button"
+                    aria-pressed={emergencyDeleteMode}
                     onClick={handleRemoveEmergency}
+                    disabled={emergencyContacts.length === 0}
                   >
                     <Trash2 className="h-4 w-4" />
                   </button>
@@ -414,18 +454,28 @@ function StudentDetails({ student }) {
           {/* EMERGENCY CONTACT: Emergency Numbers saved */}
           {showEmergency && (
             <>
-              <CopyField
-                label="Emergency Contact"
-                value={student.EmergencyContact}
-                id="copy-emergency-contact"
-                Icon={User}
-              />
-              <CopyField
-                label="Emergency Phone"
-                value={filterPhone(student.EmergencyPhone)}
-                id="copy-emergency-phone"
-                Icon={Phone}
-              />
+              {emergencyContacts.length === 0 ? (
+                <div
+                  style={{
+                    textAlign: 'center',
+                    color: '#9ca3af',
+                    fontSize: 14,
+                    padding: '1.5rem 0.5rem'
+                  }}
+                >
+                  No emergency contacts saved.
+                  <br />
+                  Tap the <strong>+</strong> button to add one.
+                </div>
+              ) : (
+                emergencyContacts.map((contact) => (
+                  <EmergencyContactCard
+                    key={contact.id}
+                    contact={contact}
+                    onRemove={emergencyDeleteMode ? handleRemoveEmergencyContact : undefined}
+                  />
+                ))
+              )}
             </>
           )}
 
@@ -551,6 +601,7 @@ function StudentDetails({ student }) {
       <AddEmergencyContactModal
         isOpen={showAddEmergencyModal}
         onClose={() => setShowAddEmergencyModal(false)}
+        onAdd={handleAddEmergencyContact}
       />
     </>
   );

--- a/react/src/services/emergencyContacts.js
+++ b/react/src/services/emergencyContacts.js
@@ -1,0 +1,150 @@
+/*
+ * emergencyContacts.js
+ *
+ * Stores per-student emergency contacts in the workbook's document settings.
+ *
+ * Contacts live under the existing `workbookSettings` document setting in an
+ * `emergencyContacts` map keyed by the student's SyStudentId (the canonical
+ * `ID`). Each entry is an array of contacts:
+ *
+ *   workbookSettings.emergencyContacts = {
+ *     "<SyStudentId>": [
+ *       { id, name, number, relationship, dateAdded }
+ *     ]
+ *   }
+ *
+ * Keying by SyStudentId means the same contacts load automatically whenever
+ * that student is viewed, on any machine that opens the workbook.
+ */
+
+const DOC_KEY = 'workbookSettings';
+const CONTACTS_KEY = 'emergencyContacts';
+
+function isOfficeReady() {
+    return typeof window !== 'undefined'
+        && window.Office
+        && Office.context
+        && Office.context.document
+        && Office.context.document.settings;
+}
+
+function readWorkbookSettings() {
+    if (!isOfficeReady()) return null;
+    try {
+        return Office.context.document.settings.get(DOC_KEY) || {};
+    } catch (err) {
+        console.warn('emergencyContacts: failed to read document settings', err);
+        return null;
+    }
+}
+
+function writeWorkbookSettings(mapping) {
+    if (!isOfficeReady()) return Promise.resolve(false);
+    return new Promise(resolve => {
+        try {
+            Office.context.document.settings.set(DOC_KEY, mapping);
+            Office.context.document.settings.saveAsync(result => {
+                const ok = result && result.status === Office.AsyncResultStatus.Succeeded;
+                if (!ok && result && result.error) {
+                    console.warn('emergencyContacts: saveAsync failed', result.error);
+                }
+                resolve(!!ok);
+            });
+        } catch (err) {
+            console.warn('emergencyContacts: failed to set document settings', err);
+            resolve(false);
+        }
+    });
+}
+
+// Normalize an identifier to a non-empty string key, or null when unusable.
+function toKey(studentId) {
+    if (studentId === null || studentId === undefined) return null;
+    const key = String(studentId).trim();
+    return key ? key : null;
+}
+
+function makeId() {
+    return `ec_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+}
+
+/**
+ * Returns the emergency contacts saved for a student (always an array).
+ * @param {string|number} studentId - The student's SyStudentId (canonical ID).
+ * @returns {Array<{id: string, name: string, number: string, relationship: string, dateAdded: string}>}
+ */
+export function getEmergencyContacts(studentId) {
+    const key = toKey(studentId);
+    if (!key) return [];
+    const settings = readWorkbookSettings();
+    if (!settings) return [];
+    const map = settings[CONTACTS_KEY];
+    if (!map || typeof map !== 'object') return [];
+    const list = map[key];
+    return Array.isArray(list) ? list : [];
+}
+
+/**
+ * Adds an emergency contact for a student and persists it.
+ * @param {string|number} studentId - The student's SyStudentId.
+ * @param {{name: string, number: string, relationship?: string}} contact
+ * @returns {Promise<Array|null>} The updated contacts array, or null on failure.
+ */
+export async function addEmergencyContact(studentId, contact) {
+    const key = toKey(studentId);
+    if (!key) {
+        console.warn('emergencyContacts: cannot add — missing student identifier');
+        return null;
+    }
+    const name = (contact && typeof contact.name === 'string') ? contact.name.trim() : '';
+    const number = (contact && typeof contact.number === 'string') ? contact.number.trim() : '';
+    const relationship = (contact && typeof contact.relationship === 'string') ? contact.relationship.trim() : '';
+    if (!name || !number) return null;
+
+    const settings = readWorkbookSettings();
+    if (!settings) return null;
+
+    const map = (settings[CONTACTS_KEY] && typeof settings[CONTACTS_KEY] === 'object')
+        ? settings[CONTACTS_KEY]
+        : {};
+    const existing = Array.isArray(map[key]) ? map[key] : [];
+
+    const record = { id: makeId(), name, number, relationship, dateAdded: new Date().toISOString() };
+    const nextList = [...existing, record];
+    const next = { ...settings, [CONTACTS_KEY]: { ...map, [key]: nextList } };
+
+    const ok = await writeWorkbookSettings(next);
+    return ok ? nextList : null;
+}
+
+/**
+ * Removes an emergency contact (by id) for a student and persists the change.
+ * @param {string|number} studentId - The student's SyStudentId.
+ * @param {string} contactId - The id of the contact to remove.
+ * @returns {Promise<Array|null>} The updated contacts array, or null on failure.
+ */
+export async function removeEmergencyContact(studentId, contactId) {
+    const key = toKey(studentId);
+    if (!key || !contactId) return null;
+
+    const settings = readWorkbookSettings();
+    if (!settings) return null;
+
+    const map = (settings[CONTACTS_KEY] && typeof settings[CONTACTS_KEY] === 'object')
+        ? settings[CONTACTS_KEY]
+        : {};
+    const existing = Array.isArray(map[key]) ? map[key] : [];
+    const nextList = existing.filter(c => c && c.id !== contactId);
+    if (nextList.length === existing.length) return existing; // nothing removed
+
+    const nextMap = { ...map };
+    if (nextList.length === 0) {
+        delete nextMap[key]; // don't leave empty arrays lying around
+    } else {
+        nextMap[key] = nextList;
+    }
+    const next = { ...settings, [CONTACTS_KEY]: nextMap };
+
+    const ok = await writeWorkbookSettings(next);
+    return ok ? nextList : null;
+}


### PR DESCRIPTION
Adds an emergencyContacts service that stores contacts under the workbookSettings document setting, keyed by the student's SyStudentId, so saved contacts load automatically when a student is viewed.

- emergencyContacts.js: get/add/remove helpers over Office document settings
- EmergencyContactCard.jsx: card displaying name, number, relationship
- Details.jsx: loads contacts on student change, renders cards with an empty state, add modal now persists via the service, and the header trash toggles a delete mode that reveals per-card removal


Claude-Session: https://claude.ai/code/session_013uPurdMYYbyphgTUbzRAHK