### PR TITLE
Format emergency phone numbers and drop heart icon

### DIFF
--- a/react/src/components/studentView/Modal/AddEmergencyContactModal.jsx
+++ b/react/src/components/studentView/Modal/AddEmergencyContactModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Phone } from 'lucide-react';
 import Modal from '../../utility/Modal';
+import { formatPhoneNumber } from '../../utility/Conversion';
 
 // Modal for adding an emergency contact.
 // Collects a name, phone number, and relationship.
@@ -105,7 +106,7 @@ const AddEmergencyContactModal = ({ isOpen, onClose, onAdd }) => {
               id="emergency-number"
               type="tel"
               value={number}
-              onChange={(e) => setNumber(e.target.value)}
+              onChange={(e) => setNumber(formatPhoneNumber(e.target.value))}
               placeholder="Phone number"
               style={inputStyle}
             />

--- a/react/src/components/studentView/Parts/EmergencyContactCard.jsx
+++ b/react/src/components/studentView/Parts/EmergencyContactCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { User, Phone, Heart, X } from 'lucide-react';
+import { User, Phone, X } from 'lucide-react';
+import { formatPhoneNumber } from '../../utility/Conversion';
 
 // Card that displays a single saved emergency contact.
 // When `onRemove` is provided, a small delete button is shown.
@@ -55,7 +56,6 @@ const EmergencyContactCard = ({ contact, onRemove }) => {
               marginLeft: 'auto',
               display: 'inline-flex',
               alignItems: 'center',
-              gap: 4,
               fontSize: 11,
               fontWeight: 600,
               color: '#b91c1c',
@@ -64,7 +64,6 @@ const EmergencyContactCard = ({ contact, onRemove }) => {
               padding: '2px 8px'
             }}
           >
-            <Heart size={11} />
             {relationship}
           </span>
         )}
@@ -77,7 +76,7 @@ const EmergencyContactCard = ({ contact, onRemove }) => {
             href={`tel:${number}`}
             style={{ color: '#374151', fontSize: 14, textDecoration: 'none' }}
           >
-            {number}
+            {formatPhoneNumber(number)}
           </a>
         </div>
       )}

--- a/react/src/components/utility/Conversion.jsx
+++ b/react/src/components/utility/Conversion.jsx
@@ -115,6 +115,25 @@ export function formatTimestamp(date = new Date()) {
   }
 }
 
+// Formats a phone number string into (XXX)-XXX-XXXX where possible.
+// - 10 digits            -> (786)-234-8749
+// - 11 digits (US, "1")  -> 1 (786)-234-8749
+// Anything else is returned unchanged so partial/invalid input isn't mangled.
+export function formatPhoneNumber(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  const digits = str.replace(/\D/g, '');
+
+  if (digits.length === 10) {
+    return `(${digits.slice(0, 3)})-${digits.slice(3, 6)}-${digits.slice(6)}`;
+  }
+  if (digits.length === 11 && digits[0] === '1') {
+    const d = digits.slice(1);
+    return `1 (${d.slice(0, 3)})-${d.slice(3, 6)}-${d.slice(6)}`;
+  }
+  return str;
+}
+
 // Usage example:
 // const date = formatExcelDate(44561); // Converts Excel date serial to JavaScript Date
 // console.log(date); // Outputs: "10/07/25 12:00 AM" (depending on the input serial)


### PR DESCRIPTION
Adds a shared formatPhoneNumber helper that renders 10-digit numbers as (786)-234-8749 (and 11-digit US numbers with a leading 1). The add modal now formats the number as it is typed, and the card displays the formatted number. Also removes the heart icon from the relationship pill on the emergency contact card.


Claude-Session: https://claude.ai/code/session_013uPurdMYYbyphgTUbzRAHK