### PR TITLE
Add loading skeleton for new emergency contact with fade-in

### DIFF
--- a/react/src/components/studentView/Parts/EmergencyContactCard.jsx
+++ b/react/src/components/studentView/Parts/EmergencyContactCard.jsx
@@ -2,6 +2,46 @@ import React from 'react';
 import { User, Phone, X } from 'lucide-react';
 import { formatPhoneNumber } from '../../utility/Conversion';
 
+const cardStyles = `
+@keyframes ecFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes ecPulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}
+.ec-fade-in { animation: ecFadeIn 0.35s ease-out; }
+.ec-skeleton-line { animation: ecPulse 1.2s ease-in-out infinite; background: #fecaca; border-radius: 6px; }
+`;
+
+// Skeleton placeholder shown while a new emergency contact is being saved.
+export const EmergencyContactSkeleton = () => (
+  <>
+    <style>{cardStyles}</style>
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'relative',
+        border: '1px solid #fecaca',
+        background: '#fef2f2',
+        borderRadius: '0.75rem',
+        padding: '0.75rem 0.875rem'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+        <div className="ec-skeleton-line" style={{ width: 16, height: 16, borderRadius: '9999px' }} />
+        <div className="ec-skeleton-line" style={{ width: '45%', height: 12 }} />
+        <div className="ec-skeleton-line" style={{ width: 56, height: 14, marginLeft: 'auto', borderRadius: '9999px' }} />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div className="ec-skeleton-line" style={{ width: 16, height: 16, borderRadius: '9999px' }} />
+        <div className="ec-skeleton-line" style={{ width: '55%', height: 12 }} />
+      </div>
+    </div>
+  </>
+);
+
 // Card that displays a single saved emergency contact.
 // When `onRemove` is provided, a small delete button is shown.
 const EmergencyContactCard = ({ contact, onRemove }) => {
@@ -11,6 +51,7 @@ const EmergencyContactCard = ({ contact, onRemove }) => {
 
   return (
     <div
+      className="ec-fade-in"
       style={{
         position: 'relative',
         border: '1px solid #fecaca',
@@ -19,6 +60,7 @@ const EmergencyContactCard = ({ contact, onRemove }) => {
         padding: '0.75rem 0.875rem'
       }}
     >
+      <style>{cardStyles}</style>
       {onRemove && (
         <button
           type="button"

--- a/react/src/components/studentView/Tabs/Details.jsx
+++ b/react/src/components/studentView/Tabs/Details.jsx
@@ -20,7 +20,7 @@ import callIcon from '../../../assets/icons/call-icon.png';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { formatExcelDate } from '../../utility/Conversion';
 import AddEmergencyContactModal from '../Modal/AddEmergencyContactModal';
-import EmergencyContactCard from '../Parts/EmergencyContactCard';
+import EmergencyContactCard, { EmergencyContactSkeleton } from '../Parts/EmergencyContactCard';
 import {
   getEmergencyContacts,
   addEmergencyContact,
@@ -293,6 +293,8 @@ function StudentDetails({ student }) {
   // Saved emergency contacts for this student, plus a delete/manage toggle.
   const [emergencyContacts, setEmergencyContacts] = useState([]);
   const [emergencyDeleteMode, setEmergencyDeleteMode] = useState(false);
+  // True while a newly added contact is being persisted (shows a loading card).
+  const [savingEmergency, setSavingEmergency] = useState(false);
 
   // The SyStudentId (canonical ID) is the identifier we key contacts by.
   const studentId = student && (student.ID ?? student.StudentNumber);
@@ -318,8 +320,13 @@ function StudentDetails({ student }) {
   };
 
   const handleAddEmergencyContact = async (contact) => {
-    const updated = await addEmergencyContact(studentId, contact);
-    if (updated) setEmergencyContacts(updated);
+    setSavingEmergency(true);
+    try {
+      const updated = await addEmergencyContact(studentId, contact);
+      if (updated) setEmergencyContacts(updated);
+    } finally {
+      setSavingEmergency(false);
+    }
   };
 
   const handleRemoveEmergencyContact = async (contact) => {
@@ -454,7 +461,7 @@ function StudentDetails({ student }) {
           {/* EMERGENCY CONTACT: Emergency Numbers saved */}
           {showEmergency && (
             <>
-              {emergencyContacts.length === 0 ? (
+              {emergencyContacts.length === 0 && !savingEmergency ? (
                 <div
                   style={{
                     textAlign: 'center',
@@ -468,13 +475,16 @@ function StudentDetails({ student }) {
                   Tap the <strong>+</strong> button to add one.
                 </div>
               ) : (
-                emergencyContacts.map((contact) => (
-                  <EmergencyContactCard
-                    key={contact.id}
-                    contact={contact}
-                    onRemove={emergencyDeleteMode ? handleRemoveEmergencyContact : undefined}
-                  />
-                ))
+                <>
+                  {emergencyContacts.map((contact) => (
+                    <EmergencyContactCard
+                      key={contact.id}
+                      contact={contact}
+                      onRemove={emergencyDeleteMode ? handleRemoveEmergencyContact : undefined}
+                    />
+                  ))}
+                  {savingEmergency && <EmergencyContactSkeleton />}
+                </>
               )}
             </>
           )}


### PR DESCRIPTION
While a newly added emergency contact is being persisted, a pulsing skeleton card is shown in its place. Once saved, the real card fades in.


Claude-Session: https://claude.ai/code/session_013uPurdMYYbyphgTUbzRAHK