### PR TITLE
Replace trash button with edit mode for emergency contacts

### DIFF
--- a/react/src/components/studentView/Parts/EmergencyContactCard.jsx
+++ b/react/src/components/studentView/Parts/EmergencyContactCard.jsx
@@ -42,12 +42,109 @@ export const EmergencyContactSkeleton = () => (
   </>
 );
 
+const editInputStyle = {
+  width: '100%',
+  padding: '6px 8px',
+  fontSize: 13,
+  color: '#1f2937',
+  background: '#fff',
+  border: '1px solid #fecaca',
+  borderRadius: 6,
+  outline: 'none',
+  boxSizing: 'border-box'
+};
+const editLabelStyle = {
+  display: 'block',
+  fontSize: 11,
+  fontWeight: 600,
+  color: '#b91c1c',
+  marginBottom: 3
+};
+
 // Card that displays a single saved emergency contact.
-// When `onRemove` is provided, a small delete button is shown.
-const EmergencyContactCard = ({ contact, onRemove }) => {
+// When `editable` is true, the fields become inputs (with an X to remove) and
+// `onChange` is called with the updated contact. `onRemove` shows a delete button.
+const EmergencyContactCard = ({ contact, editable, onChange, onRemove }) => {
   if (!contact) return null;
 
   const { name, number, relationship } = contact;
+
+  const update = (field, value) => {
+    if (onChange) onChange({ ...contact, [field]: value });
+  };
+
+  if (editable) {
+    return (
+      <div
+        className="ec-fade-in"
+        style={{
+          position: 'relative',
+          border: '1px solid #fca5a5',
+          background: '#fff',
+          borderRadius: '0.75rem',
+          padding: '0.75rem 0.875rem'
+        }}
+      >
+        <style>{cardStyles}</style>
+        {onRemove && (
+          <button
+            type="button"
+            onClick={() => onRemove(contact)}
+            aria-label={`Remove ${name || 'emergency contact'}`}
+            title="Remove"
+            style={{
+              position: 'absolute',
+              top: 6,
+              right: 6,
+              width: 22,
+              height: 22,
+              borderRadius: '9999px',
+              border: 'none',
+              background: '#fee2e2',
+              color: '#b91c1c',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer'
+            }}
+          >
+            <X size={14} />
+          </button>
+        )}
+
+        <div style={{ marginBottom: 8, paddingRight: 22 }}>
+          <label style={editLabelStyle}>Name</label>
+          <input
+            type="text"
+            value={name || ''}
+            onChange={(e) => update('name', e.target.value)}
+            placeholder="Full name"
+            style={editInputStyle}
+          />
+        </div>
+        <div style={{ marginBottom: 8 }}>
+          <label style={editLabelStyle}>Number</label>
+          <input
+            type="tel"
+            value={number || ''}
+            onChange={(e) => update('number', formatPhoneNumber(e.target.value))}
+            placeholder="Phone number"
+            style={editInputStyle}
+          />
+        </div>
+        <div>
+          <label style={editLabelStyle}>Relationship</label>
+          <input
+            type="text"
+            value={relationship || ''}
+            onChange={(e) => update('relationship', e.target.value)}
+            placeholder="e.g. Parent, Spouse, Sibling"
+            style={editInputStyle}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/react/src/components/studentView/Tabs/Details.jsx
+++ b/react/src/components/studentView/Tabs/Details.jsx
@@ -14,7 +14,7 @@ import {
   Activity,
   Phone,
   Plus,
-  Trash2
+  Pencil
 } from 'lucide-react';
 import callIcon from '../../../assets/icons/call-icon.png';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -24,7 +24,7 @@ import EmergencyContactCard, { EmergencyContactSkeleton } from '../Parts/Emergen
 import {
   getEmergencyContacts,
   addEmergencyContact,
-  removeEmergencyContact
+  saveEmergencyContacts
 } from '../../../services/emergencyContacts';
 
 // A small reusable component for displaying a single detail item.
@@ -290,9 +290,11 @@ function StudentDetails({ student }) {
   // State for the "Add Emergency Contact" modal
   const [showAddEmergencyModal, setShowAddEmergencyModal] = useState(false);
 
-  // Saved emergency contacts for this student, plus a delete/manage toggle.
+  // Saved emergency contacts for this student, plus an edit-mode toggle.
   const [emergencyContacts, setEmergencyContacts] = useState([]);
-  const [emergencyDeleteMode, setEmergencyDeleteMode] = useState(false);
+  const [emergencyEditMode, setEmergencyEditMode] = useState(false);
+  // Working copy of the contacts while editing (committed on exit).
+  const [emergencyDraft, setEmergencyDraft] = useState([]);
   // True while a newly added contact is being persisted (shows a loading card).
   const [savingEmergency, setSavingEmergency] = useState(false);
 
@@ -301,7 +303,8 @@ function StudentDetails({ student }) {
 
   // Load saved emergency contacts whenever the viewed student changes.
   useEffect(() => {
-    setEmergencyDeleteMode(false);
+    setEmergencyEditMode(false);
+    setEmergencyDraft([]);
     setEmergencyContacts(getEmergencyContacts(studentId));
   }, [studentId]);
 
@@ -314,9 +317,32 @@ function StudentDetails({ student }) {
     setShowAddEmergencyModal(true);
   };
 
-  // The header trash button toggles a delete mode that reveals per-card removal.
-  const handleRemoveEmergency = () => {
-    setEmergencyDeleteMode((prev) => !prev);
+  // The header pencil button toggles edit mode. Entering edit takes a working
+  // copy of the contacts; clicking again saves the draft and closes the state.
+  const handleToggleEmergencyEdit = async () => {
+    if (!emergencyEditMode) {
+      setEmergencyDraft(emergencyContacts.map((c) => ({ ...c })));
+      setEmergencyEditMode(true);
+      return;
+    }
+    // Exiting edit mode — persist the draft.
+    const saved = await saveEmergencyContacts(studentId, emergencyDraft);
+    if (saved) setEmergencyContacts(saved);
+    setEmergencyEditMode(false);
+    setEmergencyDraft([]);
+  };
+
+  // Update a single field of a contact within the edit draft.
+  const handleEditEmergencyContact = (updatedContact) => {
+    setEmergencyDraft((prev) =>
+      prev.map((c) => (c.id === updatedContact.id ? updatedContact : c))
+    );
+  };
+
+  // Remove a contact from the edit draft (persisted when edit mode closes).
+  const handleRemoveEmergencyContact = (contact) => {
+    if (!contact || !contact.id) return;
+    setEmergencyDraft((prev) => prev.filter((c) => c.id !== contact.id));
   };
 
   const handleAddEmergencyContact = async (contact) => {
@@ -326,15 +352,6 @@ function StudentDetails({ student }) {
       if (updated) setEmergencyContacts(updated);
     } finally {
       setSavingEmergency(false);
-    }
-  };
-
-  const handleRemoveEmergencyContact = async (contact) => {
-    if (!contact || !contact.id) return;
-    const updated = await removeEmergencyContact(studentId, contact.id);
-    if (updated) {
-      setEmergencyContacts(updated);
-      if (updated.length === 0) setEmergencyDeleteMode(false);
     }
   };
 
@@ -380,31 +397,32 @@ function StudentDetails({ student }) {
                 <div className="relative">
                   <button
                     id="add-emergency-button"
-                    className="bg-gray-500 text-white w-8 h-8 rounded-full shadow-lg flex items-center justify-center hover:bg-green-500 transition-colors"
+                    className="bg-gray-500 text-white w-8 h-8 rounded-full shadow-lg flex items-center justify-center hover:bg-green-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-gray-500"
                     aria-label="Add Emergency Number"
                     title="Add Emergency Number"
                     type="button"
                     onClick={handleAddEmergency}
+                    disabled={emergencyEditMode}
                   >
                     <Plus className="h-4 w-4" />
                   </button>
                 </div>
                 <div className="relative">
                   <button
-                    id="remove-emergency-button"
+                    id="edit-emergency-button"
                     className={`text-white w-8 h-8 rounded-full shadow-lg flex items-center justify-center transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                      emergencyDeleteMode
-                        ? 'bg-red-400 hover:bg-red-500'
-                        : 'bg-gray-500 hover:bg-red-400'
+                      emergencyEditMode
+                        ? 'bg-green-500 hover:bg-green-600'
+                        : 'bg-gray-500 hover:bg-blue-400'
                     }`}
-                    aria-label="Remove Emergency Number"
-                    title={emergencyDeleteMode ? 'Done removing' : 'Remove Emergency Number'}
+                    aria-label={emergencyEditMode ? 'Save emergency contacts' : 'Edit emergency contacts'}
+                    title={emergencyEditMode ? 'Save & close' : 'Edit emergency contacts'}
                     type="button"
-                    aria-pressed={emergencyDeleteMode}
-                    onClick={handleRemoveEmergency}
-                    disabled={emergencyContacts.length === 0}
+                    aria-pressed={emergencyEditMode}
+                    onClick={handleToggleEmergencyEdit}
+                    disabled={!emergencyEditMode && emergencyContacts.length === 0}
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Pencil className="h-4 w-4" />
                   </button>
                 </div>
               </>
@@ -461,7 +479,32 @@ function StudentDetails({ student }) {
           {/* EMERGENCY CONTACT: Emergency Numbers saved */}
           {showEmergency && (
             <>
-              {emergencyContacts.length === 0 && !savingEmergency ? (
+              {emergencyEditMode ? (
+                emergencyDraft.length === 0 ? (
+                  <div
+                    style={{
+                      textAlign: 'center',
+                      color: '#9ca3af',
+                      fontSize: 14,
+                      padding: '1.5rem 0.5rem'
+                    }}
+                  >
+                    All contacts removed.
+                    <br />
+                    Tap the pencil again to save.
+                  </div>
+                ) : (
+                  emergencyDraft.map((contact) => (
+                    <EmergencyContactCard
+                      key={contact.id}
+                      contact={contact}
+                      editable
+                      onChange={handleEditEmergencyContact}
+                      onRemove={handleRemoveEmergencyContact}
+                    />
+                  ))
+                )
+              ) : emergencyContacts.length === 0 && !savingEmergency ? (
                 <div
                   style={{
                     textAlign: 'center',
@@ -480,7 +523,6 @@ function StudentDetails({ student }) {
                     <EmergencyContactCard
                       key={contact.id}
                       contact={contact}
-                      onRemove={emergencyDeleteMode ? handleRemoveEmergencyContact : undefined}
                     />
                   ))}
                   {savingEmergency && <EmergencyContactSkeleton />}

--- a/react/src/services/emergencyContacts.js
+++ b/react/src/services/emergencyContacts.js
@@ -118,6 +118,47 @@ export async function addEmergencyContact(studentId, contact) {
 }
 
 /**
+ * Replaces the full list of emergency contacts for a student and persists it.
+ * Used to save a batch of edits (and removals) made in the edit view.
+ * @param {string|number} studentId - The student's SyStudentId.
+ * @param {Array<{id?: string, name: string, number: string, relationship?: string}>} contacts
+ * @returns {Promise<Array|null>} The saved contacts array, or null on failure.
+ */
+export async function saveEmergencyContacts(studentId, contacts) {
+    const key = toKey(studentId);
+    if (!key) return null;
+
+    const settings = readWorkbookSettings();
+    if (!settings) return null;
+
+    const map = (settings[CONTACTS_KEY] && typeof settings[CONTACTS_KEY] === 'object')
+        ? settings[CONTACTS_KEY]
+        : {};
+
+    // Normalize/sanitize the incoming list, dropping entries missing name or number.
+    const nextList = (Array.isArray(contacts) ? contacts : [])
+        .map(c => ({
+            id: (c && typeof c.id === 'string' && c.id) ? c.id : makeId(),
+            name: (c && typeof c.name === 'string') ? c.name.trim() : '',
+            number: (c && typeof c.number === 'string') ? c.number.trim() : '',
+            relationship: (c && typeof c.relationship === 'string') ? c.relationship.trim() : '',
+            dateAdded: (c && typeof c.dateAdded === 'string') ? c.dateAdded : new Date().toISOString()
+        }))
+        .filter(c => c.name && c.number);
+
+    const nextMap = { ...map };
+    if (nextList.length === 0) {
+        delete nextMap[key];
+    } else {
+        nextMap[key] = nextList;
+    }
+    const next = { ...settings, [CONTACTS_KEY]: nextMap };
+
+    const ok = await writeWorkbookSettings(next);
+    return ok ? nextList : null;
+}
+
+/**
  * Removes an emergency contact (by id) for a student and persists the change.
  * @param {string|number} studentId - The student's SyStudentId.
  * @param {string} contactId - The id of the contact to remove.


### PR DESCRIPTION
The header button is now a pencil that toggles edit mode. In edit mode each card becomes editable (name, number, relationship) with an X to remove it. Clicking the pencil again persists all edits/removals and closes the state.

- emergencyContacts.js: add saveEmergencyContacts to persist the full list
- EmergencyContactCard.jsx: editable variant with inputs and remove button
- Details.jsx: pencil toggle keeps a working draft, commits on exit; Add is disabled while editing


Claude-Session: https://claude.ai/code/session_013uPurdMYYbyphgTUbzRAHK