### PR TITLE
Harden emergency contact edit mode

### DIFF
--- a/react/src/components/studentView/Parts/EmergencyContactCard.jsx
+++ b/react/src/components/studentView/Parts/EmergencyContactCard.jsx
@@ -64,7 +64,8 @@ const editLabelStyle = {
 // Card that displays a single saved emergency contact.
 // When `editable` is true, the fields become inputs (with an X to remove) and
 // `onChange` is called with the updated contact. `onRemove` shows a delete button.
-const EmergencyContactCard = ({ contact, editable, onChange, onRemove }) => {
+// `highlightInvalid` marks empty required fields (name/number) after a blocked save.
+const EmergencyContactCard = ({ contact, editable, onChange, onRemove, highlightInvalid }) => {
   if (!contact) return null;
 
   const { name, number, relationship } = contact;
@@ -72,6 +73,10 @@ const EmergencyContactCard = ({ contact, editable, onChange, onRemove }) => {
   const update = (field, value) => {
     if (onChange) onChange({ ...contact, [field]: value });
   };
+
+  const nameMissing = !(name || '').trim();
+  const numberMissing = !(number || '').trim();
+  const invalidStyle = { borderColor: '#ef4444', background: '#fef2f2' };
 
   if (editable) {
     return (
@@ -119,7 +124,7 @@ const EmergencyContactCard = ({ contact, editable, onChange, onRemove }) => {
             value={name || ''}
             onChange={(e) => update('name', e.target.value)}
             placeholder="Full name"
-            style={editInputStyle}
+            style={{ ...editInputStyle, ...(highlightInvalid && nameMissing ? invalidStyle : {}) }}
           />
         </div>
         <div style={{ marginBottom: 8 }}>
@@ -129,7 +134,7 @@ const EmergencyContactCard = ({ contact, editable, onChange, onRemove }) => {
             value={number || ''}
             onChange={(e) => update('number', formatPhoneNumber(e.target.value))}
             placeholder="Phone number"
-            style={editInputStyle}
+            style={{ ...editInputStyle, ...(highlightInvalid && numberMissing ? invalidStyle : {}) }}
           />
         </div>
         <div>
@@ -142,6 +147,11 @@ const EmergencyContactCard = ({ contact, editable, onChange, onRemove }) => {
             style={editInputStyle}
           />
         </div>
+        {highlightInvalid && (nameMissing || numberMissing) && (
+          <p style={{ margin: '8px 0 0', fontSize: 11, fontWeight: 600, color: '#ef4444' }}>
+            Name and number are required — fill them in or remove this contact.
+          </p>
+        )}
       </div>
     );
   }

--- a/react/src/components/studentView/Tabs/Details.jsx
+++ b/react/src/components/studentView/Tabs/Details.jsx
@@ -24,7 +24,8 @@ import EmergencyContactCard, { EmergencyContactSkeleton } from '../Parts/Emergen
 import {
   getEmergencyContacts,
   addEmergencyContact,
-  saveEmergencyContacts
+  saveEmergencyContacts,
+  contactListsEqual
 } from '../../../services/emergencyContacts';
 
 // A small reusable component for displaying a single detail item.
@@ -297,14 +298,24 @@ function StudentDetails({ student }) {
   const [emergencyDraft, setEmergencyDraft] = useState([]);
   // True while a newly added contact is being persisted (shows a loading card).
   const [savingEmergency, setSavingEmergency] = useState(false);
+  // True while the edit draft is being persisted (guards double pencil clicks).
+  const [savingEmergencyEdit, setSavingEmergencyEdit] = useState(false);
+  // Set after a blocked save so invalid (empty) required fields get flagged.
+  const [showEmergencyValidation, setShowEmergencyValidation] = useState(false);
+  // Non-empty when the last save attempt failed — edits stay open so nothing is lost.
+  const [emergencyEditError, setEmergencyEditError] = useState('');
 
   // The SyStudentId (canonical ID) is the identifier we key contacts by.
   const studentId = student && (student.ID ?? student.StudentNumber);
 
   // Load saved emergency contacts whenever the viewed student changes.
+  // Any in-progress draft is discarded on purpose — carrying edits across
+  // students would risk writing one student's contacts onto another.
   useEffect(() => {
     setEmergencyEditMode(false);
     setEmergencyDraft([]);
+    setShowEmergencyValidation(false);
+    setEmergencyEditError('');
     setEmergencyContacts(getEmergencyContacts(studentId));
   }, [studentId]);
 
@@ -317,19 +328,52 @@ function StudentDetails({ student }) {
     setShowAddEmergencyModal(true);
   };
 
+  const closeEmergencyEdit = () => {
+    setEmergencyEditMode(false);
+    setEmergencyDraft([]);
+    setShowEmergencyValidation(false);
+    setEmergencyEditError('');
+  };
+
   // The header pencil button toggles edit mode. Entering edit takes a working
   // copy of the contacts; clicking again saves the draft and closes the state.
   const handleToggleEmergencyEdit = async () => {
+    if (savingEmergencyEdit) return; // save already in flight
     if (!emergencyEditMode) {
       setEmergencyDraft(emergencyContacts.map((c) => ({ ...c })));
       setEmergencyEditMode(true);
       return;
     }
-    // Exiting edit mode — persist the draft.
-    const saved = await saveEmergencyContacts(studentId, emergencyDraft);
-    if (saved) setEmergencyContacts(saved);
-    setEmergencyEditMode(false);
-    setEmergencyDraft([]);
+
+    // Block the save if any remaining contact lost its name or number —
+    // saveEmergencyContacts would silently drop those entries.
+    const hasInvalid = emergencyDraft.some(
+      (c) => !(c.name || '').trim() || !(c.number || '').trim()
+    );
+    if (hasInvalid) {
+      setShowEmergencyValidation(true);
+      return;
+    }
+
+    // Nothing changed — just close, no saveAsync round-trip.
+    if (contactListsEqual(emergencyDraft, emergencyContacts)) {
+      closeEmergencyEdit();
+      return;
+    }
+
+    setSavingEmergencyEdit(true);
+    try {
+      const saved = await saveEmergencyContacts(studentId, emergencyDraft);
+      if (saved) {
+        setEmergencyContacts(saved);
+        closeEmergencyEdit();
+      } else {
+        // Keep edit mode (and the draft) open so the edits aren't lost.
+        setEmergencyEditError("Couldn't save changes — try again.");
+      }
+    } finally {
+      setSavingEmergencyEdit(false);
+    }
   };
 
   // Update a single field of a contact within the edit draft.
@@ -420,7 +464,11 @@ function StudentDetails({ student }) {
                     type="button"
                     aria-pressed={emergencyEditMode}
                     onClick={handleToggleEmergencyEdit}
-                    disabled={!emergencyEditMode && emergencyContacts.length === 0}
+                    disabled={
+                      savingEmergencyEdit ||
+                      savingEmergency || // don't snapshot a stale list while an add is persisting
+                      (!emergencyEditMode && emergencyContacts.length === 0)
+                    }
                   >
                     <Pencil className="h-4 w-4" />
                   </button>
@@ -480,30 +528,49 @@ function StudentDetails({ student }) {
           {showEmergency && (
             <>
               {emergencyEditMode ? (
-                emergencyDraft.length === 0 ? (
-                  <div
-                    style={{
-                      textAlign: 'center',
-                      color: '#9ca3af',
-                      fontSize: 14,
-                      padding: '1.5rem 0.5rem'
-                    }}
-                  >
-                    All contacts removed.
-                    <br />
-                    Tap the pencil again to save.
-                  </div>
-                ) : (
-                  emergencyDraft.map((contact) => (
-                    <EmergencyContactCard
-                      key={contact.id}
-                      contact={contact}
-                      editable
-                      onChange={handleEditEmergencyContact}
-                      onRemove={handleRemoveEmergencyContact}
-                    />
-                  ))
-                )
+                <>
+                  {emergencyEditError && (
+                    <div
+                      role="alert"
+                      style={{
+                        textAlign: 'center',
+                        color: '#b91c1c',
+                        background: '#fee2e2',
+                        borderRadius: '0.5rem',
+                        fontSize: 13,
+                        fontWeight: 600,
+                        padding: '0.5rem'
+                      }}
+                    >
+                      {emergencyEditError}
+                    </div>
+                  )}
+                  {emergencyDraft.length === 0 ? (
+                    <div
+                      style={{
+                        textAlign: 'center',
+                        color: '#9ca3af',
+                        fontSize: 14,
+                        padding: '1.5rem 0.5rem'
+                      }}
+                    >
+                      All contacts removed.
+                      <br />
+                      Tap the pencil again to save.
+                    </div>
+                  ) : (
+                    emergencyDraft.map((contact) => (
+                      <EmergencyContactCard
+                        key={contact.id}
+                        contact={contact}
+                        editable
+                        onChange={handleEditEmergencyContact}
+                        onRemove={handleRemoveEmergencyContact}
+                        highlightInvalid={showEmergencyValidation}
+                      />
+                    ))
+                  )}
+                </>
               ) : emergencyContacts.length === 0 && !savingEmergency ? (
                 <div
                   style={{

--- a/react/src/services/__tests__/emergencyContacts.test.js
+++ b/react/src/services/__tests__/emergencyContacts.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { contactListsEqual } from '../emergencyContacts';
+
+const contact = (over = {}) => ({
+    id: 'ec_1',
+    name: 'Jane Doe',
+    number: '(786)-234-8749',
+    relationship: 'Parent',
+    ...over
+});
+
+describe('contactListsEqual', () => {
+    it('treats identical lists as equal', () => {
+        expect(contactListsEqual([contact()], [contact()])).toBe(true);
+        expect(contactListsEqual([], [])).toBe(true);
+    });
+
+    it('ignores surrounding whitespace so trim-only edits are not saved', () => {
+        expect(contactListsEqual(
+            [contact({ name: '  Jane Doe ' })],
+            [contact()]
+        )).toBe(true);
+    });
+
+    it('detects field edits', () => {
+        expect(contactListsEqual([contact()], [contact({ name: 'Janet Doe' })])).toBe(false);
+        expect(contactListsEqual([contact()], [contact({ number: '(305)-111-2222' })])).toBe(false);
+        expect(contactListsEqual([contact()], [contact({ relationship: 'Spouse' })])).toBe(false);
+    });
+
+    it('detects added and removed contacts', () => {
+        expect(contactListsEqual([contact()], [])).toBe(false);
+        expect(contactListsEqual([], [contact()])).toBe(false);
+        expect(contactListsEqual(
+            [contact()],
+            [contact(), contact({ id: 'ec_2' })]
+        )).toBe(false);
+    });
+
+    it('ignores non-visible fields like dateAdded', () => {
+        expect(contactListsEqual(
+            [contact({ dateAdded: '2026-01-01T00:00:00Z' })],
+            [contact({ dateAdded: '2026-06-30T00:00:00Z' })]
+        )).toBe(true);
+    });
+
+    it('tolerates non-array input', () => {
+        expect(contactListsEqual(null, [])).toBe(true);
+        expect(contactListsEqual(undefined, [contact()])).toBe(false);
+    });
+});

--- a/react/src/services/emergencyContacts.js
+++ b/react/src/services/emergencyContacts.js
@@ -68,6 +68,21 @@ function makeId() {
     return `ec_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
 }
 
+// True when two contact lists hold the same entries in the same order.
+// Compares the user-visible fields (id, name, number, relationship).
+export function contactListsEqual(a, b) {
+    const listA = Array.isArray(a) ? a : [];
+    const listB = Array.isArray(b) ? b : [];
+    if (listA.length !== listB.length) return false;
+    return listA.every((c, i) => {
+        const o = listB[i] || {};
+        return (c?.id || '') === (o.id || '')
+            && ((c?.name || '').trim()) === ((o.name || '').trim())
+            && ((c?.number || '').trim()) === ((o.number || '').trim())
+            && ((c?.relationship || '').trim()) === ((o.relationship || '').trim());
+    });
+}
+
 /**
  * Returns the emergency contacts saved for a student (always an array).
  * @param {string|number} studentId - The student's SyStudentId (canonical ID).
@@ -145,6 +160,10 @@ export async function saveEmergencyContacts(studentId, contacts) {
             dateAdded: (c && typeof c.dateAdded === 'string') ? c.dateAdded : new Date().toISOString()
         }))
         .filter(c => c.name && c.number);
+
+    // Nothing actually changed — skip the saveAsync round-trip.
+    const existing = Array.isArray(map[key]) ? map[key] : [];
+    if (contactListsEqual(nextList, existing)) return existing;
 
     const nextMap = { ...map };
     if (nextList.length === 0) {


### PR DESCRIPTION
Closes several gaps in the edit flow:

- Skip the saveAsync round-trip when the draft is unchanged (checked in the component via contactListsEqual, and again in the service as a backstop, mirroring workbookUsers' up-to-date skip)
- Block save-and-close while a contact is missing its name or number — previously those entries were silently dropped on save. Invalid fields get flagged in red with an inline message
- Keep edit mode and the draft open when the save fails, with an error banner, instead of silently discarding the edits
- Disable the pencil while an add is persisting (the draft would snapshot a stale list and overwrite the new contact) and while an edit save is in flight (double-click guard)

Adds unit tests for contactListsEqual.


Claude-Session: https://claude.ai/code/session_013uPurdMYYbyphgTUbzRAHK