### PR TITLE
Add Risk Index: daily LDA history snapshot, RI column, and student vi…

### DIFF
--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -8,6 +8,7 @@
 import React, { useState, useEffect } from 'react';
 import { Info, CheckCircle2, Circle, Loader2, ArrowLeft, AlertCircle, ChevronRight, Plus, Pencil, Trash2, X, ClipboardList } from 'lucide-react';
 import { createLDA, detectCampuses, detectProgramVersions, predictAdvisorDistribution, checkMissingLDAColumns, addColumnsToMasterList, checkMasterListExists } from './ldaProcessor';
+import { DEFAULT_RISK_INDEX_SETTINGS, sanitizeRiskIndexSettings } from './riskIndex';
 
 // --- CONFIGURATION: Steps matching the processor logic ---
 const PROCESS_STEPS = [
@@ -40,12 +41,13 @@ export default function CreateLDAManager({ onReady } = {}) {
     advisorAssignment: {
       enabled: false,
       advisors: []
-    }
+    },
+    riskIndex: { ...DEFAULT_RISK_INDEX_SETTINGS }
   });
 
   // State for View Management: 'settings' | 'processing' | 'done' | 'error'
   const [view, setView] = useState('settings');
-  const [settingsView, setSettingsView] = useState('main'); // 'main' | 'tags' | 'assigned' | 'inclusions'
+  const [settingsView, setSettingsView] = useState('main'); // 'main' | 'tags' | 'assigned' | 'inclusions' | 'riskIndex'
   const [errorMessage, setErrorMessage] = useState('');
 
   // State for Progress Tracking: { [stepId]: 'pending' | 'active' | 'completed' }
@@ -115,6 +117,7 @@ export default function CreateLDAManager({ onReady } = {}) {
           dncColor: (typeof wb.dncColor === 'string' && wb.dncColor) ? wb.dncColor : prev.dncColor,
           sheetNameMode: wb.sheetNameMode || prev.sheetNameMode,
           advisorAssignment: wb.advisorAssignment || prev.advisorAssignment,
+          riskIndex: wb.riskIndex ? sanitizeRiskIndexSettings(wb.riskIndex) : prev.riskIndex,
         }));
       }
     };
@@ -181,24 +184,24 @@ export default function CreateLDAManager({ onReady } = {}) {
   const handleSettingChange = (key, value) => {
     setLdaSettings((prev) => {
       const next = { ...prev, [key]: value };
-      // Persist advisorAssignment to workbook settings
-      if (key === 'advisorAssignment') {
-        saveAdvisorAssignmentToWorkbook(value);
+      // Persist shared config (advisor assignment, risk index) to workbook settings
+      if (key === 'advisorAssignment' || key === 'riskIndex') {
+        saveToWorkbookSettings(key, value);
       }
       return next;
     });
   };
 
-  const saveAdvisorAssignmentToWorkbook = (advisorAssignment) => {
+  const saveToWorkbookSettings = (key, value) => {
     try {
       if (typeof window !== 'undefined' && window.Office && Office.context && Office.context.document && Office.context.document.settings) {
         const wb = Office.context.document.settings.get('workbookSettings') || {};
-        wb.advisorAssignment = advisorAssignment;
+        wb[key] = value;
         Office.context.document.settings.set('workbookSettings', wb);
         Office.context.document.settings.saveAsync(() => {});
       }
     } catch (e) {
-      console.error('Failed to save advisor assignment:', e);
+      console.error(`Failed to save ${key}:`, e);
     }
   };
 
@@ -723,6 +726,16 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
     );
   }
 
+  if (settingsView === 'riskIndex') {
+    return (
+      <RiskIndexSettings
+        settings={settings}
+        onSettingChange={onSettingChange}
+        onBack={() => setSettingsView('main')}
+      />
+    );
+  }
+
   if (settingsView === 'inclusions') {
     return (
       <div className="flex flex-col gap-4 w-full animate-in fade-in slide-in-from-right-4 duration-300">
@@ -879,6 +892,91 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
         </div>
         <ChevronRight className="w-4 h-4 text-slate-400" />
       </button>
+
+      <button
+        type="button"
+        onClick={() => setSettingsView('riskIndex')}
+        className="flex items-center justify-between p-3 bg-slate-50/50 rounded-xl border border-slate-100/50 hover:border-slate-200 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-slate-700 font-medium text-sm">Risk Index</span>
+          <Info
+            title="Track how many times each student has hit the risk threshold of days out."
+            className="w-4 h-4 text-slate-400 cursor-help hover:text-slate-600"
+          />
+          {settings.riskIndex?.enabled && (
+            <span className="text-[10px] font-semibold text-white bg-[#145F82] px-1.5 py-0.5 rounded-full">ON</span>
+          )}
+        </div>
+        <ChevronRight className="w-4 h-4 text-slate-400" />
+      </button>
+    </div>
+  );
+}
+
+// --- Risk Index Settings ---
+
+function RiskIndexSettings({ settings, onSettingChange, onBack }) {
+  const riskIndex = settings.riskIndex || { ...DEFAULT_RISK_INDEX_SETTINGS };
+
+  const updateRiskIndex = (updates) => {
+    onSettingChange('riskIndex', { ...riskIndex, ...updates });
+  };
+
+  return (
+    <div className="flex flex-col gap-4 w-full animate-in fade-in slide-in-from-right-4 duration-300">
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex items-center gap-1 text-slate-400 hover:text-slate-600 text-sm font-medium transition-colors w-fit"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Back
+      </button>
+
+      <ToggleRow
+        key="toggle-risk-index"
+        label="Track Risk Index"
+        tooltip="Save a daily snapshot of every student's LDA and Days Out (stored under LDAHistory in workbook settings) each time an LDA sheet is created — once per day."
+        isOn={riskIndex.enabled}
+        onToggle={() => updateRiskIndex({ enabled: !riskIndex.enabled })}
+      />
+
+      <div className={`flex flex-col gap-4 transition-all duration-300 overflow-hidden ${riskIndex.enabled ? 'opacity-100 max-h-96' : 'opacity-0 max-h-0'}`}>
+        <div className="flex items-center justify-between p-3 bg-slate-50/50 rounded-xl border border-slate-100/50 hover:border-slate-200 transition-colors">
+          <div className="flex items-center gap-2">
+            <label htmlFor="riskThreshold" className="text-slate-700 font-medium text-sm">
+              Risk Threshold
+            </label>
+            <Info
+              title="Days Out value that counts as a drop-risk hit. Reaching it counts once per drop (per LDA), no matter how many days the student stays out."
+              className="w-4 h-4 text-slate-400 cursor-help hover:text-slate-600"
+            />
+          </div>
+          <input
+            id="riskThreshold"
+            type="number"
+            min="1"
+            value={riskIndex.threshold}
+            onChange={(e) => updateRiskIndex({ threshold: Number(e.target.value) })}
+            className="w-24 border border-slate-200 bg-white rounded-lg px-3 py-1.5 text-right text-sm focus:outline-none focus:ring-2 focus:ring-[#145F82]/20 focus:border-[#145F82] transition-all"
+          />
+        </div>
+
+        <ToggleRow
+          key="toggle-risk-column"
+          label={
+            <span className="inline-flex items-center gap-2">
+              Show
+              <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-red-200 text-red-800">RI</span>
+              Column
+            </span>
+          }
+          tooltip="Add an RI (Risk Index) column next to Days Out on the LDA sheet showing how many times each student has hit the risk threshold."
+          isOn={riskIndex.showColumn}
+          onToggle={() => updateRiskIndex({ showColumn: !riskIndex.showColumn })}
+        />
+      </div>
     </div>
   );
 }

--- a/react/src/components/createLDA/__tests__/riskIndex.test.js
+++ b/react/src/components/createLDA/__tests__/riskIndex.test.js
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import {
+    sanitizeRiskIndexSettings,
+    DEFAULT_RISK_INDEX_SETTINGS,
+    todayKey,
+    normalizeLdaValue,
+    buildDailySnapshot,
+    mergeSnapshot,
+    countRiskEpisodes,
+    countRiskEpisodesForStudent,
+    lookupRiskCount,
+} from '../riskIndex.js';
+
+describe('sanitizeRiskIndexSettings', () => {
+    it('returns defaults for missing/invalid input', () => {
+        expect(sanitizeRiskIndexSettings(undefined)).toEqual(DEFAULT_RISK_INDEX_SETTINGS);
+        expect(sanitizeRiskIndexSettings(null)).toEqual(DEFAULT_RISK_INDEX_SETTINGS);
+        expect(sanitizeRiskIndexSettings('nope')).toEqual(DEFAULT_RISK_INDEX_SETTINGS);
+    });
+
+    it('keeps explicit values', () => {
+        expect(sanitizeRiskIndexSettings({ enabled: false, threshold: 10, showColumn: false }))
+            .toEqual({ enabled: false, threshold: 10, showColumn: false });
+    });
+
+    it('falls back to default threshold for invalid numbers', () => {
+        expect(sanitizeRiskIndexSettings({ threshold: 'abc' }).threshold).toBe(14);
+        expect(sanitizeRiskIndexSettings({ threshold: 0 }).threshold).toBe(14);
+        expect(sanitizeRiskIndexSettings({ threshold: -3 }).threshold).toBe(14);
+        expect(sanitizeRiskIndexSettings({ threshold: 14.9 }).threshold).toBe(14);
+    });
+
+    it('fills only missing fields with defaults', () => {
+        expect(sanitizeRiskIndexSettings({ enabled: false }))
+            .toEqual({ enabled: false, threshold: 14, showColumn: true });
+    });
+});
+
+describe('todayKey', () => {
+    it('formats a local calendar date as YYYY-MM-DD', () => {
+        expect(todayKey(new Date(2026, 6, 21))).toBe('2026-07-21');
+        expect(todayKey(new Date(2026, 0, 5))).toBe('2026-01-05');
+    });
+});
+
+describe('normalizeLdaValue', () => {
+    it('returns null for empty values', () => {
+        expect(normalizeLdaValue(null)).toBeNull();
+        expect(normalizeLdaValue(undefined)).toBeNull();
+        expect(normalizeLdaValue('')).toBeNull();
+        expect(normalizeLdaValue('   ')).toBeNull();
+    });
+
+    it('converts Excel date serials without timezone drift', () => {
+        // 45000 = 2023-03-15 (44927 = 2023-01-01)
+        expect(normalizeLdaValue(45000)).toBe('2023-03-15');
+        expect(normalizeLdaValue(44927)).toBe('2023-01-01');
+    });
+
+    it('parses common date strings', () => {
+        expect(normalizeLdaValue('7/10/2026')).toBe('2026-07-10');
+        expect(normalizeLdaValue('12/1/2025')).toBe('2025-12-01');
+    });
+
+    it('keeps ISO strings as-is', () => {
+        expect(normalizeLdaValue('2026-07-10')).toBe('2026-07-10');
+    });
+
+    it('keeps unparseable strings verbatim so they still key episodes', () => {
+        expect(normalizeLdaValue('N/A')).toBe('N/A');
+    });
+
+    it('stringifies out-of-range numbers instead of treating them as serials', () => {
+        expect(normalizeLdaValue(7)).toBe('7');
+    });
+});
+
+describe('buildDailySnapshot', () => {
+    const headers = ['SyStudentID', 'Student Name', 'LDA', 'Days Out'];
+    const idx = { idIdx: 0, ldaIdx: 2, daysOutIdx: 3 };
+
+    it('captures id, normalized LDA, and days out per student', () => {
+        const values = [
+            headers,
+            [101, 'Ada', 45000, 14],
+            ['102 ', 'Ben', '7/10/2026', 3],
+        ];
+        expect(buildDailySnapshot(values, idx)).toEqual({
+            '101': { lda: '2023-03-15', daysOut: 14 },
+            '102': { lda: '2026-07-10', daysOut: 3 },
+        });
+    });
+
+    it('skips rows with no id or non-numeric days out', () => {
+        const values = [
+            headers,
+            ['', 'NoId', 45000, 14],
+            [103, 'NoDays', 45000, ''],
+            [104, 'TextDays', 45000, 'n/a'],
+        ];
+        expect(buildDailySnapshot(values, idx)).toEqual({});
+    });
+
+    it('handles a missing LDA column', () => {
+        const values = [headers, [105, 'Eve', null, 7]];
+        expect(buildDailySnapshot(values, { ...idx, ldaIdx: -1 })).toEqual({
+            '105': { lda: null, daysOut: 7 },
+        });
+    });
+
+    it('returns empty for missing required indices', () => {
+        expect(buildDailySnapshot([headers, [1, 'x', 2, 3]], { idIdx: -1, ldaIdx: 2, daysOutIdx: 3 })).toEqual({});
+        expect(buildDailySnapshot(null, idx)).toEqual({});
+    });
+});
+
+describe('mergeSnapshot', () => {
+    it('adds a new date entry', () => {
+        const history = mergeSnapshot({ version: 1, days: {} }, '2026-07-21', { '1': { lda: 'a', daysOut: 5 } });
+        expect(history).toEqual({ version: 1, days: { '2026-07-21': { '1': { lda: 'a', daysOut: 5 } } } });
+    });
+
+    it('overwrites the same day on re-runs and keeps other days', () => {
+        const day1 = { '1': { lda: 'a', daysOut: 5 } };
+        let history = mergeSnapshot({ version: 1, days: { '2026-07-20': day1 } }, '2026-07-21', { '1': { lda: 'a', daysOut: 6 } });
+        history = mergeSnapshot(history, '2026-07-21', { '1': { lda: 'a', daysOut: 7 } });
+        expect(Object.keys(history.days)).toEqual(['2026-07-20', '2026-07-21']);
+        expect(history.days['2026-07-21']['1'].daysOut).toBe(7);
+        expect(history.days['2026-07-20']).toEqual(day1);
+    });
+
+    it('tolerates malformed prior history', () => {
+        expect(mergeSnapshot(undefined, '2026-07-21', {}).days['2026-07-21']).toEqual({});
+        expect(mergeSnapshot({ bogus: true }, '2026-07-21', {}).days['2026-07-21']).toEqual({});
+    });
+});
+
+describe('countRiskEpisodes', () => {
+    const historyOf = (days) => ({ version: 1, days });
+
+    it('counts consecutive days at threshold with the same LDA as one episode', () => {
+        const history = historyOf({
+            '2026-07-20': { '1': { lda: '2026-07-06', daysOut: 14 } },
+            '2026-07-21': { '1': { lda: '2026-07-06', daysOut: 15 } },
+            '2026-07-22': { '1': { lda: '2026-07-06', daysOut: 16 } },
+        });
+        expect(countRiskEpisodes(history, 14).get('1')).toBe(1);
+    });
+
+    it('counts a re-drop (new LDA) as a second episode', () => {
+        const history = historyOf({
+            '2026-07-20': { '1': { lda: '2026-07-06', daysOut: 14 } },
+            '2026-07-25': { '1': { lda: '2026-07-24', daysOut: 1 } },
+            '2026-08-10': { '1': { lda: '2026-07-27', daysOut: 14 } },
+        });
+        expect(countRiskEpisodes(history, 14).get('1')).toBe(2);
+    });
+
+    it('ignores students who never reach the threshold', () => {
+        const history = historyOf({
+            '2026-07-20': { '1': { lda: 'x', daysOut: 13 }, '2': { lda: 'y', daysOut: 14 } },
+        });
+        const counts = countRiskEpisodes(history, 14);
+        expect(counts.has('1')).toBe(false);
+        expect(counts.get('2')).toBe(1);
+    });
+
+    it('collapses missing-LDA hits into a single episode', () => {
+        const history = historyOf({
+            '2026-07-20': { '1': { lda: null, daysOut: 14 } },
+            '2026-07-21': { '1': { lda: null, daysOut: 15 } },
+        });
+        expect(countRiskEpisodes(history, 14).get('1')).toBe(1);
+    });
+
+    it('respects a custom threshold', () => {
+        const history = historyOf({
+            '2026-07-20': { '1': { lda: 'a', daysOut: 10 } },
+        });
+        expect(countRiskEpisodes(history, 10).get('1')).toBe(1);
+        expect(countRiskEpisodes(history, 14).has('1')).toBe(false);
+    });
+
+    it('handles empty or malformed history', () => {
+        expect(countRiskEpisodes(undefined, 14).size).toBe(0);
+        expect(countRiskEpisodes({ days: { '2026-07-20': null } }, 14).size).toBe(0);
+    });
+});
+
+describe('countRiskEpisodesForStudent', () => {
+    const history = {
+        version: 1,
+        days: {
+            '2026-07-20': { '1': { lda: 'a', daysOut: 14 }, '2': { lda: 'b', daysOut: 20 } },
+            '2026-07-21': { '1': { lda: 'a', daysOut: 15 } },
+            '2026-08-10': { '1': { lda: 'c', daysOut: 14 } },
+        },
+    };
+
+    it('matches the full-map count for a single student', () => {
+        expect(countRiskEpisodesForStudent(history, '1', 14)).toBe(countRiskEpisodes(history, 14).get('1'));
+        expect(countRiskEpisodesForStudent(history, '1', 14)).toBe(2);
+        expect(countRiskEpisodesForStudent(history, '2', 14)).toBe(1);
+    });
+
+    it('accepts numeric ids and trims strings', () => {
+        expect(countRiskEpisodesForStudent(history, 1, 14)).toBe(2);
+        expect(countRiskEpisodesForStudent(history, ' 1 ', 14)).toBe(2);
+    });
+
+    it('returns 0 for unknown or empty ids', () => {
+        expect(countRiskEpisodesForStudent(history, '999', 14)).toBe(0);
+        expect(countRiskEpisodesForStudent(history, '', 14)).toBe(0);
+        expect(countRiskEpisodesForStudent(null, '1', 14)).toBe(0);
+    });
+});
+
+describe('lookupRiskCount', () => {
+    it('returns the first matching id variant', () => {
+        const map = new Map([['12345', 3], ['S-99', 1]]);
+        expect(lookupRiskCount(map, ['12345'])).toBe(3);
+        expect(lookupRiskCount(map, ['nope', 'S-99'])).toBe(1);
+        expect(lookupRiskCount(map, ['nope'])).toBe(0);
+        expect(lookupRiskCount(map, [])).toBe(0);
+    });
+});

--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -11,7 +11,8 @@
 import { getWorkbookSettings } from '../utility/getSettings';
 import { defaultColumns } from '../settings/DefaultSettings';
 import { MASTER_LIST_SHEET, HISTORY_SHEET, BATCH_SIZE } from '../../../../shared/constants.js';
-import { STUDENT_ID_ALIASES, STUDENT_NUMBER_ALIASES } from '../../../../shared/columnAliases.js';
+import { STUDENT_ID_ALIASES, STUDENT_NUMBER_ALIASES, LAST_LDA_ALIASES } from '../../../../shared/columnAliases.js';
+import { sanitizeRiskIndexSettings, buildDailySnapshot, mergeSnapshot, countRiskEpisodes, lookupRiskCount, loadLdaHistory, saveLdaHistory, todayKey } from './riskIndex.js';
 
 const SHEET_NAMES = {
     MASTER_LIST: MASTER_LIST_SHEET,
@@ -40,6 +41,7 @@ const FIXED_COLUMN_WIDTHS = {
     grade: 45.75,              // 61px (Last Course Grade — settings name is "Grade")
     lastcoursegrade: 45.75,    // 61px (when shown under its raw master header)
     nextassignmentdue: 92.25,  // 123px
+    ri: 30,                    // 40px (Risk Index)
 };
 const WRAP_COLUMN_NAMES = new Set(['outreach']);
 const normalizeColName = (name) => String(name || '').toLowerCase().replace(/\s+/g, '');
@@ -306,7 +308,8 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
             dncColor: userOverrides.dncColor ?? '#f2bdbd',
             sheetNameMode: userOverrides.sheetNameMode ?? 'date',
             columns: workbookSettings.columns,
-            advisorAssignment: userOverrides.advisorAssignment ?? { enabled: false, advisors: [] }
+            advisorAssignment: userOverrides.advisorAssignment ?? { enabled: false, advisors: [] },
+            riskIndex: sanitizeRiskIndexSettings(userOverrides.riskIndex)
         };
 
         await Excel.run(async (context) => {
@@ -518,6 +521,32 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
             }
 
             if (daysOutIdx === -1) throw new Error("Could not find 'Days Out' column in Master List. Check Settings.");
+
+            // --- Risk Index: daily LDA/Days Out snapshot + episode counts ---
+            // One snapshot per calendar day for the whole Master List (a same-day
+            // re-run overwrites that day's entry), stored under the LDAHistory
+            // document setting. The counts feed the RI output column and the
+            // student view badge.
+            let riskIndexMap = new Map();
+            const riskEnabled = settings.riskIndex.enabled && studentIdIdx !== -1;
+            if (riskEnabled) {
+                const ldaColIdx = findColIdxByAliases(LAST_LDA_ALIASES);
+                const snapshot = buildDailySnapshot(masterValues, { idIdx: studentIdIdx, ldaIdx: ldaColIdx, daysOutIdx });
+                const ldaHistory = mergeSnapshot(loadLdaHistory(), todayKey(), snapshot);
+                saveLdaHistory(ldaHistory);
+                riskIndexMap = countRiskEpisodes(ldaHistory, settings.riskIndex.threshold);
+            }
+            if (riskEnabled && settings.riskIndex.showColumn) {
+                // Place RI right after Days Out; the column is synthetic (no
+                // Master List source), flagged so buildOutputRow fills it.
+                const riColumn = { name: 'RI', riskIndex: true };
+                const daysOutOutIdx = outputColumns.findIndex(c => getColIndex(c.name) === daysOutIdx);
+                if (daysOutOutIdx !== -1) {
+                    outputColumns.splice(daysOutOutIdx + 1, 0, riColumn);
+                } else {
+                    outputColumns.push(riColumn);
+                }
+            }
 
             // Look for "Course Start" column
             let courseStartIdx = getColIndex('Course Start');
@@ -1128,7 +1157,7 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
                     }
                     outputColumns.forEach((colConfig, colOutIdx) => {
                         const masterIdx = getColIndex(colConfig.name);
-                        let val = (masterIdx !== -1) ? rowObj.values[masterIdx] : "";
+                        let val = (masterIdx !== -1) ? rowObj.values[masterIdx] : (colConfig.riskIndex ? lookupRiskCount(riskIndexMap, sIds) : "");
                         let form = (masterIdx !== -1) ? rowObj.formulas[masterIdx] : null;
                         if (colConfig.name === 'Gradebook' && form && String(form).startsWith('=HYPERLINK')) {
                             // Keep formula
@@ -1531,7 +1560,7 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
 
                     outputColumns.forEach((colConfig, colOutIdx) => {
                         const masterIdx = getColIndex(colConfig.name);
-                        let val = (masterIdx !== -1) ? rowObj.values[masterIdx] : "";
+                        let val = (masterIdx !== -1) ? rowObj.values[masterIdx] : (colConfig.riskIndex ? lookupRiskCount(riskIndexMap, sIds) : "");
                         let form = (masterIdx !== -1) ? rowObj.formulas[masterIdx] : null;
 
                         if (colConfig.name === 'Gradebook' && form && String(form).startsWith('=HYPERLINK')) {

--- a/react/src/components/createLDA/riskIndex.js
+++ b/react/src/components/createLDA/riskIndex.js
@@ -1,0 +1,188 @@
+/*
+ * Risk Index — daily LDA/Days Out history and drop-episode counting.
+ *
+ * Every Create LDA run stores a snapshot of the whole Master List (SyStudentId,
+ * LDA, Days Out) in the document settings under the `LDAHistory` key, keyed by
+ * calendar date. Re-running on the same day overwrites that day's snapshot, so
+ * there is at most one entry per day.
+ *
+ * A student's Risk Index is the number of separate drop episodes in which they
+ * reached the risk threshold (default 14 days out). Episodes are keyed by the
+ * student's LDA value: sitting at 14, 15, 16 days out across consecutive
+ * snapshots shares one LDA and counts once; attending again (new LDA) and
+ * dropping back to the threshold counts as a new episode. This also keeps the
+ * count correct across weekends/holidays when no LDA sheet is created.
+ */
+
+/* global Office */
+
+export const LDA_HISTORY_KEY = 'LDAHistory';
+
+export const DEFAULT_RISK_INDEX_SETTINGS = {
+    enabled: true,
+    threshold: 14,
+    showColumn: true,
+};
+
+export function sanitizeRiskIndexSettings(raw) {
+    const defaults = { ...DEFAULT_RISK_INDEX_SETTINGS };
+    if (!raw || typeof raw !== 'object') return defaults;
+    const threshold = Number(raw.threshold);
+    return {
+        enabled: (raw.enabled !== undefined) ? !!raw.enabled : defaults.enabled,
+        threshold: (Number.isFinite(threshold) && threshold >= 1) ? Math.floor(threshold) : defaults.threshold,
+        showColumn: (raw.showColumn !== undefined) ? !!raw.showColumn : defaults.showColumn,
+    };
+}
+
+const pad2 = (n) => String(n).padStart(2, '0');
+
+/** Local calendar date key, e.g. '2026-07-21'. */
+export function todayKey(date = new Date()) {
+    return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+/**
+ * Normalize an LDA cell value to a stable episode key ('YYYY-MM-DD' when the
+ * value is a recognizable date). Excel serials use UTC math so the calendar
+ * day never shifts with the local timezone. Unparseable strings are kept
+ * verbatim — they still work as episode keys. Empty values return null.
+ */
+export function normalizeLdaValue(val) {
+    if (val === null || val === undefined || val === '') return null;
+    if (typeof val === 'number') {
+        if (val < 20000 || val > 80000) return String(val);
+        const d = new Date(Math.round((val - 25569) * 86400000));
+        return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+    }
+    const str = String(val).trim();
+    if (!str) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(str)) return str;
+    const parsed = new Date(str);
+    if (!isNaN(parsed.getTime()) && parsed.getFullYear() > 1990 && parsed.getFullYear() < 2100) {
+        return `${parsed.getFullYear()}-${pad2(parsed.getMonth() + 1)}-${pad2(parsed.getDate())}`;
+    }
+    return str;
+}
+
+/**
+ * Build one day's snapshot from the Master List value matrix (row 0 = headers).
+ * Rows without a student id or a numeric Days Out are skipped.
+ * @returns {Object} { [studentId]: { lda: string|null, daysOut: number } }
+ */
+export function buildDailySnapshot(masterValues, { idIdx, ldaIdx, daysOutIdx }) {
+    const snapshot = {};
+    if (!Array.isArray(masterValues) || idIdx === -1 || daysOutIdx === -1) return snapshot;
+    for (let i = 1; i < masterValues.length; i++) {
+        const row = masterValues[i];
+        if (!row) continue;
+        const rawId = row[idIdx];
+        if (rawId === null || rawId === undefined || rawId === '') continue;
+        const id = String(rawId).trim();
+        if (!id) continue;
+        const daysOut = row[daysOutIdx];
+        if (typeof daysOut !== 'number') continue;
+        snapshot[id] = {
+            lda: (ldaIdx !== -1) ? normalizeLdaValue(row[ldaIdx]) : null,
+            daysOut,
+        };
+    }
+    return snapshot;
+}
+
+/** Set (or overwrite) one date's snapshot in the history object. */
+export function mergeSnapshot(history, dateKey, snapshot) {
+    const days = (history && typeof history === 'object' && history.days && typeof history.days === 'object')
+        ? { ...history.days }
+        : {};
+    days[dateKey] = snapshot;
+    return { version: 1, days };
+}
+
+// Episode key for a snapshot entry: the LDA when known, otherwise a shared
+// sentinel so unknown-LDA hits collapse into a single episode instead of
+// counting every snapshot day separately.
+const episodeKey = (entry) => entry.lda || 'unknown';
+
+/**
+ * Count drop episodes per student across the whole history.
+ * @returns {Map<string, number>} studentId -> number of distinct LDAs that
+ *   reached `threshold`+ days out.
+ */
+export function countRiskEpisodes(history, threshold) {
+    const episodes = new Map(); // id -> Set of episode keys
+    const days = (history && history.days) || {};
+    for (const dateKey of Object.keys(days)) {
+        const snapshot = days[dateKey];
+        if (!snapshot || typeof snapshot !== 'object') continue;
+        for (const id of Object.keys(snapshot)) {
+            const entry = snapshot[id];
+            if (!entry || typeof entry.daysOut !== 'number' || entry.daysOut < threshold) continue;
+            if (!episodes.has(id)) episodes.set(id, new Set());
+            episodes.get(id).add(episodeKey(entry));
+        }
+    }
+    const counts = new Map();
+    for (const [id, keys] of episodes) counts.set(id, keys.size);
+    return counts;
+}
+
+/** Same count for a single student without walking every other student. */
+export function countRiskEpisodesForStudent(history, studentId, threshold) {
+    if (!studentId) return 0;
+    const id = String(studentId).trim();
+    const keys = new Set();
+    const days = (history && history.days) || {};
+    for (const dateKey of Object.keys(days)) {
+        const entry = days[dateKey] && days[dateKey][id];
+        if (!entry || typeof entry.daysOut !== 'number' || entry.daysOut < threshold) continue;
+        keys.add(episodeKey(entry));
+    }
+    return keys.size;
+}
+
+/** First matching count for any of the student's id variants (SyStudentId, Student Number). */
+export function lookupRiskCount(riskIndexMap, ids) {
+    for (const id of ids) {
+        if (riskIndexMap.has(id)) return riskIndexMap.get(id);
+    }
+    return 0;
+}
+
+// --- Document settings IO (no-ops outside an Office host) ---
+
+export function loadLdaHistory() {
+    try {
+        if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
+            const stored = Office.context.document.settings.get(LDA_HISTORY_KEY);
+            if (stored && typeof stored === 'object') return stored;
+        }
+    } catch (e) {
+        console.warn('riskIndex: failed to read LDAHistory setting', e);
+    }
+    return { version: 1, days: {} };
+}
+
+export function saveLdaHistory(history) {
+    try {
+        if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
+            Office.context.document.settings.set(LDA_HISTORY_KEY, history);
+            Office.context.document.settings.saveAsync(() => {});
+        }
+    } catch (e) {
+        console.warn('riskIndex: failed to save LDAHistory setting', e);
+    }
+}
+
+/** Current Risk Index config from workbook settings (sanitized, with defaults). */
+export function getRiskIndexConfig() {
+    try {
+        if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
+            const wb = Office.context.document.settings.get('workbookSettings');
+            return sanitizeRiskIndexSettings(wb && wb.riskIndex);
+        }
+    } catch (e) {
+        console.warn('riskIndex: failed to read workbookSettings', e);
+    }
+    return { ...DEFAULT_RISK_INDEX_SETTINGS };
+}

--- a/react/src/components/studentView/Parts/Header.jsx
+++ b/react/src/components/studentView/Parts/Header.jsx
@@ -4,6 +4,7 @@ import { User } from 'lucide-react';
 import { formatName } from '../../utility/Conversion';
 import BounceAnimation from '../../utility/BounceAnimation';
 import DaysOutModal from '../Modal/DaysOutModal';
+import { getRiskIndexConfig, loadLdaHistory, countRiskEpisodesForStudent } from '../../createLDA/riskIndex';
 
 function StudentHeader({ student, selectedRowCount = 1 }) {
   // Use a fallback student object to prevent errors if the prop is null or undefined
@@ -20,6 +21,22 @@ function StudentHeader({ student, selectedRowCount = 1 }) {
   const assignedTo = safeStudent.Assigned;
 
   const daysOut = safeStudent.DaysOut ?? '--'; // Using nullish coalescing to allow 0
+
+  // --- Risk Index: how many separate times this student hit the risk
+  // threshold (default 14 days out), from the LDAHistory document setting
+  // written by Create LDA. Shown as a badge on the Days Out tile when > 0.
+  const riskStudentId = safeStudent.ID ?? safeStudent.StudentNumber ?? null;
+  const risk = React.useMemo(() => {
+    if (riskStudentId === null || riskStudentId === undefined || riskStudentId === '') return null;
+    try {
+      const cfg = getRiskIndexConfig();
+      if (!cfg.enabled) return null;
+      const count = countRiskEpisodesForStudent(loadLdaHistory(), String(riskStudentId).trim(), cfg.threshold);
+      return count > 0 ? { count, threshold: cfg.threshold } : null;
+    } catch {
+      return null;
+    }
+  }, [riskStudentId]);
   // Determine background color for Days Out
   let daysOutBg = 'bg-gray-200';
   let daysOutText = 'text-gray-800';
@@ -344,6 +361,7 @@ function StudentHeader({ student, selectedRowCount = 1 }) {
           <button
             type="button"
             className={`p-2 text-center rounded-lg ${daysOutBg} ${daysOutText} w-20 focus:outline-none`}
+            style={{ position: 'relative' }}
             onClick={() => setShowDaysModal(true)}
             aria-label="Show days out details"
             title="Show days out details"
@@ -352,6 +370,33 @@ function StudentHeader({ student, selectedRowCount = 1 }) {
             <div className={`text-xs font-medium uppercase ${daysOutLabelText}`}>
               {daysOut === 0 ? 'Engaged' : daysOut === 1 ? 'Day Out' : 'Days Out'}
             </div>
+            {risk && (
+              <span
+                aria-label={`Risk Index: hit ${risk.threshold}+ days out ${risk.count} ${risk.count === 1 ? 'time' : 'times'}`}
+                role="status"
+                title={`Risk Index: hit ${risk.threshold}+ days out ${risk.count} ${risk.count === 1 ? 'time' : 'times'}`}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  transform: 'translate(30%, -30%)',
+                  background: '#991b1b', // red-800
+                  color: '#ffffff',
+                  borderRadius: 9999,
+                  fontSize: 10,
+                  minWidth: 18,
+                  padding: '2px 5px',
+                  fontWeight: 700,
+                  boxShadow: '0 1px 2px rgba(0,0,0,0.25)',
+                  pointerEvents: 'auto',
+                  lineHeight: 1.2,
+                  zIndex: 10
+                }}
+                tabIndex={0}
+              >
+                {risk.count}
+              </span>
+            )}
           </button>
           <button
             type="button"


### PR DESCRIPTION
…ew badge

Every Create LDA run now saves a once-per-day snapshot of the whole Master List (SyStudentId, LDA, Days Out) under the LDAHistory document-settings key, keyed by date; re-running on the same day overwrites that day's entry.

A student's Risk Index counts their separate drop episodes: distinct LDA values that ever reached the risk threshold (default 14 days out). Sitting at 14/15/16 across consecutive days counts once; attending again and re-dropping counts as a new episode.

- react/src/components/createLDA/riskIndex.js: pure snapshot/merge/count logic plus document-settings IO, with tests
- ldaProcessor: writes the snapshot during Create LDA and inserts a synthetic RI column next to Days Out on the generated sheet (both the single/date and multi-campus flows)
- Student view header: red badge on the Days Out tile showing the count when a student has hit the threshold at least once
- Create LDA settings: new Risk Index configure page (enable, threshold, RI column toggle), persisted to workbookSettings.riskIndex


Claude-Session: https://claude.ai/code/session_01TfXnnBXcwpXuxKwv5oMwo5