### PR TITLE
Move Risk Index config to Settings taskpane; add history import and d…

### DIFF
--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -47,7 +47,7 @@ export default function CreateLDAManager({ onReady } = {}) {
 
   // State for View Management: 'settings' | 'processing' | 'done' | 'error'
   const [view, setView] = useState('settings');
-  const [settingsView, setSettingsView] = useState('main'); // 'main' | 'tags' | 'assigned' | 'inclusions' | 'riskIndex'
+  const [settingsView, setSettingsView] = useState('main'); // 'main' | 'tags' | 'assigned' | 'inclusions'
   const [errorMessage, setErrorMessage] = useState('');
 
   // State for Progress Tracking: { [stepId]: 'pending' | 'active' | 'completed' }
@@ -117,7 +117,13 @@ export default function CreateLDAManager({ onReady } = {}) {
           dncColor: (typeof wb.dncColor === 'string' && wb.dncColor) ? wb.dncColor : prev.dncColor,
           sheetNameMode: wb.sheetNameMode || prev.sheetNameMode,
           advisorAssignment: wb.advisorAssignment || prev.advisorAssignment,
-          riskIndex: wb.riskIndex ? sanitizeRiskIndexSettings(wb.riskIndex) : prev.riskIndex,
+          // Threshold and RI-column live on the Settings taskpane as flat keys;
+          // the Create LDA page only surfaces the enabled toggle.
+          riskIndex: sanitizeRiskIndexSettings({
+            enabled: wb.riskIndexEnabled,
+            threshold: wb.riskIndexThreshold,
+            showColumn: wb.riskIndexShowColumn,
+          }),
         }));
       }
     };
@@ -184,9 +190,13 @@ export default function CreateLDAManager({ onReady } = {}) {
   const handleSettingChange = (key, value) => {
     setLdaSettings((prev) => {
       const next = { ...prev, [key]: value };
-      // Persist shared config (advisor assignment, risk index) to workbook settings
-      if (key === 'advisorAssignment' || key === 'riskIndex') {
+      // Persist shared config to workbook settings
+      if (key === 'advisorAssignment') {
         saveToWorkbookSettings(key, value);
+      } else if (key === 'riskIndex') {
+        // Only the enabled flag is editable here; threshold and RI-column are
+        // flat keys owned by the Settings taskpane.
+        saveToWorkbookSettings('riskIndexEnabled', !!value.enabled);
       }
       return next;
     });
@@ -726,15 +736,6 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
     );
   }
 
-  if (settingsView === 'riskIndex') {
-    return (
-      <RiskIndexSettings
-        settings={settings}
-        onSettingChange={onSettingChange}
-        onBack={() => setSettingsView('main')}
-      />
-    );
-  }
 
   if (settingsView === 'inclusions') {
     return (
@@ -770,6 +771,20 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
           tooltip="Use each student's next assignment due date in retention messaging."
           isOn={settings.includeNextAssignmentDue}
           onToggle={() => handleToggle('includeNextAssignmentDue')}
+        />
+
+        <ToggleRow
+          key="toggle-risk-index"
+          label={
+            <span className="inline-flex items-center gap-2">
+              Include
+              <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-red-200 text-red-800">RI</span>
+              Risk Index
+            </span>
+          }
+          tooltip="Save today's LDA/Days Out snapshot and add the RI column showing how many times each student hit the risk threshold. Configure it in Settings under Risk Index."
+          isOn={settings.riskIndex?.enabled ?? true}
+          onToggle={() => onSettingChange('riskIndex', { ...settings.riskIndex, enabled: !(settings.riskIndex?.enabled ?? true) })}
         />
       </div>
     );
@@ -844,6 +859,7 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
           settings.includeFailingList,
           settings.includeAttendanceList,
           settings.includeNextAssignmentDue,
+          settings.riskIndex?.enabled ?? true,
         ].filter(Boolean).length;
         return (
           <button
@@ -893,90 +909,6 @@ function LDASettings({ settings, onSettingChange, settingsView, setSettingsView 
         <ChevronRight className="w-4 h-4 text-slate-400" />
       </button>
 
-      <button
-        type="button"
-        onClick={() => setSettingsView('riskIndex')}
-        className="flex items-center justify-between p-3 bg-slate-50/50 rounded-xl border border-slate-100/50 hover:border-slate-200 transition-colors"
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-slate-700 font-medium text-sm">Risk Index</span>
-          <Info
-            title="Track how many times each student has hit the risk threshold of days out."
-            className="w-4 h-4 text-slate-400 cursor-help hover:text-slate-600"
-          />
-          {settings.riskIndex?.enabled && (
-            <span className="text-[10px] font-semibold text-white bg-[#145F82] px-1.5 py-0.5 rounded-full">ON</span>
-          )}
-        </div>
-        <ChevronRight className="w-4 h-4 text-slate-400" />
-      </button>
-    </div>
-  );
-}
-
-// --- Risk Index Settings ---
-
-function RiskIndexSettings({ settings, onSettingChange, onBack }) {
-  const riskIndex = settings.riskIndex || { ...DEFAULT_RISK_INDEX_SETTINGS };
-
-  const updateRiskIndex = (updates) => {
-    onSettingChange('riskIndex', { ...riskIndex, ...updates });
-  };
-
-  return (
-    <div className="flex flex-col gap-4 w-full animate-in fade-in slide-in-from-right-4 duration-300">
-      <button
-        type="button"
-        onClick={onBack}
-        className="flex items-center gap-1 text-slate-400 hover:text-slate-600 text-sm font-medium transition-colors w-fit"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back
-      </button>
-
-      <ToggleRow
-        key="toggle-risk-index"
-        label="Track Risk Index"
-        tooltip="Save a daily snapshot of every student's LDA and Days Out (stored under LDAHistory in workbook settings) each time an LDA sheet is created — once per day."
-        isOn={riskIndex.enabled}
-        onToggle={() => updateRiskIndex({ enabled: !riskIndex.enabled })}
-      />
-
-      <div className={`flex flex-col gap-4 transition-all duration-300 overflow-hidden ${riskIndex.enabled ? 'opacity-100 max-h-96' : 'opacity-0 max-h-0'}`}>
-        <div className="flex items-center justify-between p-3 bg-slate-50/50 rounded-xl border border-slate-100/50 hover:border-slate-200 transition-colors">
-          <div className="flex items-center gap-2">
-            <label htmlFor="riskThreshold" className="text-slate-700 font-medium text-sm">
-              Risk Threshold
-            </label>
-            <Info
-              title="Days Out value that counts as a drop-risk hit. Reaching it counts once per drop (per LDA), no matter how many days the student stays out."
-              className="w-4 h-4 text-slate-400 cursor-help hover:text-slate-600"
-            />
-          </div>
-          <input
-            id="riskThreshold"
-            type="number"
-            min="1"
-            value={riskIndex.threshold}
-            onChange={(e) => updateRiskIndex({ threshold: Number(e.target.value) })}
-            className="w-24 border border-slate-200 bg-white rounded-lg px-3 py-1.5 text-right text-sm focus:outline-none focus:ring-2 focus:ring-[#145F82]/20 focus:border-[#145F82] transition-all"
-          />
-        </div>
-
-        <ToggleRow
-          key="toggle-risk-column"
-          label={
-            <span className="inline-flex items-center gap-2">
-              Show
-              <span className="px-2 py-0.5 text-xs font-semibold rounded-full bg-red-200 text-red-800">RI</span>
-              Column
-            </span>
-          }
-          tooltip="Add an RI (Risk Index) column next to Days Out on the LDA sheet showing how many times each student has hit the risk threshold."
-          isOn={riskIndex.showColumn}
-          onToggle={() => updateRiskIndex({ showColumn: !riskIndex.showColumn })}
-        />
-      </div>
     </div>
   );
 }

--- a/react/src/components/createLDA/__tests__/riskIndex.test.js
+++ b/react/src/components/createLDA/__tests__/riskIndex.test.js
@@ -9,6 +9,10 @@ import {
     countRiskEpisodes,
     countRiskEpisodesForStudent,
     lookupRiskCount,
+    parseLdaSheetName,
+    resolveSnapshotIndices,
+    mergeImportedDays,
+    historyToCsv,
 } from '../riskIndex.js';
 
 describe('sanitizeRiskIndexSettings', () => {
@@ -222,5 +226,101 @@ describe('lookupRiskCount', () => {
         expect(lookupRiskCount(map, ['nope', 'S-99'])).toBe(1);
         expect(lookupRiskCount(map, ['nope'])).toBe(0);
         expect(lookupRiskCount(map, [])).toBe(0);
+    });
+});
+
+describe('parseLdaSheetName', () => {
+    it('parses date-mode LDA sheet names into date keys', () => {
+        expect(parseLdaSheetName('LDA 7-21-2026')).toBe('2026-07-21');
+        expect(parseLdaSheetName('LDA 12-1-2025')).toBe('2025-12-01');
+        expect(parseLdaSheetName('lda 1-05-2026')).toBe('2026-01-05');
+    });
+
+    it('accepts same-day re-run suffixes', () => {
+        expect(parseLdaSheetName('LDA 7-21-2026 (2)')).toBe('2026-07-21');
+    });
+
+    it('rejects non-LDA and campus-mode sheet names', () => {
+        expect(parseLdaSheetName('Master List')).toBeNull();
+        expect(parseLdaSheetName('Downtown Campus')).toBeNull();
+        expect(parseLdaSheetName('LDA')).toBeNull();
+        expect(parseLdaSheetName('LDA 13-40-2026')).toBeNull();
+        expect(parseLdaSheetName('LDA 7-21-26')).toBeNull();
+        expect(parseLdaSheetName('')).toBeNull();
+        expect(parseLdaSheetName(null)).toBeNull();
+    });
+});
+
+describe('resolveSnapshotIndices', () => {
+    it('finds SyStudentID, LDA, and Days Out columns by alias', () => {
+        expect(resolveSnapshotIndices(['Student Name', 'SyStudentID', 'LDA', 'Days Out']))
+            .toEqual({ idIdx: 1, ldaIdx: 2, daysOutIdx: 3 });
+    });
+
+    it('normalizes header case and whitespace', () => {
+        expect(resolveSnapshotIndices(['STUDENT ID', 'Last Date of Attendance', ' days  out ']))
+            .toEqual({ idIdx: 0, ldaIdx: 1, daysOutIdx: 2 });
+    });
+
+    it('falls back to Student Number when no SyStudentID column exists', () => {
+        expect(resolveSnapshotIndices(['Student Number', 'LDA', 'Days Out']).idIdx).toBe(0);
+    });
+
+    it('returns -1 for missing columns', () => {
+        expect(resolveSnapshotIndices(['Foo', 'Bar'])).toEqual({ idIdx: -1, ldaIdx: -1, daysOutIdx: -1 });
+        expect(resolveSnapshotIndices(undefined)).toEqual({ idIdx: -1, ldaIdx: -1, daysOutIdx: -1 });
+    });
+});
+
+describe('mergeImportedDays', () => {
+    const existing = { version: 1, days: { '2026-07-21': { '1': { lda: 'real', daysOut: 14 } } } };
+
+    it('adds new dates and never overwrites existing snapshots', () => {
+        const { history, added, skipped } = mergeImportedDays(existing, {
+            '2026-07-21': { '1': { lda: 'backfilled', daysOut: 99 } },
+            '2026-07-14': { '1': { lda: 'old', daysOut: 7 } },
+        });
+        expect(added).toEqual(['2026-07-14']);
+        expect(skipped).toEqual(['2026-07-21']);
+        expect(history.days['2026-07-21']['1'].lda).toBe('real');
+        expect(history.days['2026-07-14']['1'].lda).toBe('old');
+    });
+
+    it('handles empty inputs', () => {
+        expect(mergeImportedDays(undefined, {})).toEqual({ history: { version: 1, days: {} }, added: [], skipped: [] });
+        const noop = mergeImportedDays(existing, undefined);
+        expect(noop.history).toEqual(existing);
+        expect(noop.added).toEqual([]);
+    });
+});
+
+describe('historyToCsv', () => {
+    it('flattens the history sorted by date then id, with a header row', () => {
+        const csv = historyToCsv({
+            version: 1,
+            days: {
+                '2026-07-21': { '20': { lda: '2026-07-07', daysOut: 14 }, '10': { lda: null, daysOut: 3 } },
+                '2026-07-14': { '10': { lda: '2026-07-01', daysOut: 13 } },
+            },
+        });
+        expect(csv.split('\n')).toEqual([
+            'Date,SyStudentID,LDA,Days Out',
+            '2026-07-14,10,2026-07-01,13',
+            '2026-07-21,10,,3',
+            '2026-07-21,20,2026-07-07,14',
+        ]);
+    });
+
+    it('escapes cells containing commas or quotes', () => {
+        const csv = historyToCsv({
+            version: 1,
+            days: { '2026-07-21': { 'a,b': { lda: 'x"y', daysOut: 5 } } },
+        });
+        expect(csv.split('\n')[1]).toBe('2026-07-21,"a,b","x""y",5');
+    });
+
+    it('returns just the header for empty history', () => {
+        expect(historyToCsv(undefined)).toBe('Date,SyStudentID,LDA,Days Out');
+        expect(historyToCsv({ version: 1, days: {} })).toBe('Date,SyStudentID,LDA,Days Out');
     });
 });

--- a/react/src/components/createLDA/riskIndex.js
+++ b/react/src/components/createLDA/riskIndex.js
@@ -14,7 +14,10 @@
  * count correct across weekends/holidays when no LDA sheet is created.
  */
 
-/* global Office */
+/* global Office, Excel */
+
+import { findColumnIndex, normalizeHeader } from '../../../../shared/excel-helpers.js';
+import { STUDENT_ID_ALIASES, STUDENT_NUMBER_ALIASES, LAST_LDA_ALIASES, DAYS_OUT_ALIASES } from '../../../../shared/columnAliases.js';
 
 export const LDA_HISTORY_KEY = 'LDAHistory';
 
@@ -141,6 +144,133 @@ export function countRiskEpisodesForStudent(history, studentId, threshold) {
     return keys.size;
 }
 
+/**
+ * Parse a date-mode LDA sheet name ("LDA 7-21-2026", including same-day
+ * re-run suffixes like "LDA 7-21-2026 (2)") into a history date key.
+ * @returns {string|null} 'YYYY-MM-DD', or null when the name doesn't match.
+ */
+export function parseLdaSheetName(name) {
+    const match = String(name || '').trim().match(/^lda (\d{1,2})-(\d{1,2})-(\d{4})(?: \(\d+\))?$/i);
+    if (!match) return null;
+    const [, month, day, year] = match;
+    if (Number(month) < 1 || Number(month) > 12 || Number(day) < 1 || Number(day) > 31) return null;
+    return `${year}-${pad2(Number(month))}-${pad2(Number(day))}`;
+}
+
+/**
+ * Resolve the snapshot column indices from a raw header row (LDA sheets carry
+ * the Master List's columns, some hidden). Student id prefers SyStudentId and
+ * falls back to Student Number for legacy workbooks.
+ * @returns {{ idIdx: number, ldaIdx: number, daysOutIdx: number }}
+ */
+export function resolveSnapshotIndices(headers) {
+    const normalized = (Array.isArray(headers) ? headers : []).map(normalizeHeader);
+    const idIdx = (() => {
+        const sy = findColumnIndex(normalized, STUDENT_ID_ALIASES);
+        return sy !== -1 ? sy : findColumnIndex(normalized, STUDENT_NUMBER_ALIASES);
+    })();
+    return {
+        idIdx,
+        ldaIdx: findColumnIndex(normalized, LAST_LDA_ALIASES),
+        daysOutIdx: findColumnIndex(normalized, DAYS_OUT_ALIASES),
+    };
+}
+
+/**
+ * Merge imported day snapshots into the history WITHOUT overwriting dates that
+ * already exist — real Create LDA snapshots always win over backfilled data.
+ * @returns {{ history: Object, added: string[], skipped: string[] }}
+ */
+export function mergeImportedDays(history, importedDays) {
+    const days = (history && typeof history === 'object' && history.days && typeof history.days === 'object')
+        ? { ...history.days }
+        : {};
+    const added = [];
+    const skipped = [];
+    for (const dateKey of Object.keys(importedDays || {})) {
+        if (Object.prototype.hasOwnProperty.call(days, dateKey)) {
+            skipped.push(dateKey);
+        } else {
+            days[dateKey] = importedDays[dateKey];
+            added.push(dateKey);
+        }
+    }
+    return { history: { version: 1, days }, added: added.sort(), skipped: skipped.sort() };
+}
+
+/** Flatten the history into CSV (Date, SyStudentID, LDA, Days Out), sorted by date then id. */
+export function historyToCsv(history) {
+    const escape = (v) => {
+        const str = v === null || v === undefined ? '' : String(v);
+        return (/[",\n]/.test(str)) ? `"${str.replace(/"/g, '""')}"` : str;
+    };
+    const lines = ['Date,SyStudentID,LDA,Days Out'];
+    const days = (history && history.days) || {};
+    for (const dateKey of Object.keys(days).sort()) {
+        const snapshot = days[dateKey];
+        if (!snapshot || typeof snapshot !== 'object') continue;
+        for (const id of Object.keys(snapshot).sort()) {
+            const entry = snapshot[id] || {};
+            lines.push([dateKey, id, entry.lda ?? '', entry.daysOut ?? ''].map(escape).join(','));
+        }
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Backfill LDAHistory from the workbook's previous date-mode LDA sheets.
+ * Reads every sheet named like "LDA M-D-YYYY", extracts each student's
+ * LDA/Days Out, and merges the results into the stored history — never
+ * overwriting dates that already have a snapshot. Non-LDA rows on those
+ * sheets (titles, spacer rows, secondary table headers) are skipped by the
+ * numeric Days Out requirement.
+ * @returns {Promise<{ scanned: number, added: string[], skipped: string[], unreadable: string[] }>}
+ */
+export async function importHistoryFromLdaSheets() {
+    if (typeof Excel === 'undefined' || !Excel.run) {
+        throw new Error('Excel API not available');
+    }
+    return Excel.run(async (context) => {
+        const sheets = context.workbook.worksheets;
+        sheets.load('items/name');
+        await context.sync();
+
+        const targets = sheets.items
+            .map(s => ({ name: s.name, dateKey: parseLdaSheetName(s.name) }))
+            .filter(t => t.dateKey);
+
+        const importedDays = {};
+        const unreadable = [];
+        for (const target of targets) {
+            const used = sheets.getItem(target.name).getUsedRangeOrNullObject();
+            used.load('values');
+            await context.sync();
+            if (used.isNullObject || !used.values || used.values.length < 2) {
+                unreadable.push(target.name);
+                continue;
+            }
+            const values = used.values;
+            const indices = resolveSnapshotIndices(values[0]);
+            if (indices.idIdx === -1 || indices.daysOutIdx === -1) {
+                unreadable.push(target.name);
+                continue;
+            }
+            const snapshot = buildDailySnapshot(values, indices);
+            if (Object.keys(snapshot).length === 0) {
+                unreadable.push(target.name);
+                continue;
+            }
+            // Same-day duplicates ("LDA 7-21-2026 (2)") are later runs of that
+            // day; iterate in sheet order so the last one wins within the import.
+            importedDays[target.dateKey] = snapshot;
+        }
+
+        const { history, added, skipped } = mergeImportedDays(loadLdaHistory(), importedDays);
+        if (added.length > 0) saveLdaHistory(history);
+        return { scanned: targets.length, added, skipped, unreadable };
+    });
+}
+
 /** First matching count for any of the student's id variants (SyStudentId, Student Number). */
 export function lookupRiskCount(riskIndexMap, ids) {
     for (const id of ids) {
@@ -174,12 +304,20 @@ export function saveLdaHistory(history) {
     }
 }
 
-/** Current Risk Index config from workbook settings (sanitized, with defaults). */
+/**
+ * Current Risk Index config from workbook settings (sanitized, with defaults).
+ * Stored as flat keys (riskIndexEnabled, riskIndexThreshold,
+ * riskIndexShowColumn) to match the Settings page's schema-driven rows.
+ */
 export function getRiskIndexConfig() {
     try {
         if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
-            const wb = Office.context.document.settings.get('workbookSettings');
-            return sanitizeRiskIndexSettings(wb && wb.riskIndex);
+            const wb = Office.context.document.settings.get('workbookSettings') || {};
+            return sanitizeRiskIndexSettings({
+                enabled: wb.riskIndexEnabled,
+                threshold: wb.riskIndexThreshold,
+                showColumn: wb.riskIndexShowColumn,
+            });
         }
     } catch (e) {
         console.warn('riskIndex: failed to read workbookSettings', e);

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -135,6 +135,46 @@ export const defaultWorkbookSettings = [
 		description: 'Fill color for DNC outreach comments and the phone-column strikethrough.'
 	},
 	{
+		id: 'riskIndexEnabled',
+		label: 'Track Risk Index',
+		type: 'boolean',
+		defaultValue: true,
+		section: 'Risk Index',
+		description: 'Save a daily snapshot of every student\'s LDA and Days Out (stored under LDAHistory in workbook settings) each time an LDA sheet is created — once per day.'
+	},
+	{
+		id: 'riskIndexThreshold',
+		label: 'Risk Threshold',
+		type: 'number',
+		defaultValue: 14,
+		section: 'Risk Index',
+		description: 'Days Out value that counts as a drop-risk hit. Reaching it counts once per drop (per LDA), no matter how many days the student stays out.'
+	},
+	{
+		id: 'riskIndexShowColumn',
+		label: 'RI Column',
+		type: 'boolean',
+		defaultValue: true,
+		section: 'Risk Index',
+		description: 'Add an RI (Risk Index) column next to Days Out on the LDA sheet showing how many times each student has hit the risk threshold.'
+	},
+	{
+		id: 'importLdaHistory',
+		label: 'Import Past Reports',
+		type: 'action',
+		defaultValue: null,
+		section: 'Risk Index',
+		description: 'Scan previous "LDA M-D-YYYY" sheets in this workbook and backfill the history from them. Dates that already have a snapshot are left untouched.'
+	},
+	{
+		id: 'downloadLdaHistory',
+		label: 'Download History',
+		type: 'action',
+		defaultValue: null,
+		section: 'Risk Index',
+		description: 'Download the saved LDA history (date, student ID, LDA, days out) as a CSV file.'
+	},
+	{
 		id: 'powerAutomateUrl',
 		label: 'Power Automate',
 		type: 'powerautomate',
@@ -227,6 +267,13 @@ export const sectionIcons = {
 	'Send Emails': (
 		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 			<path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+		</svg>
+	),
+	'Risk Index': (
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+			<path d="M12 21a9 9 0 1 1 9-9" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+			<path d="M12 12l4.5-4.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+			<circle cx="12" cy="12" r="1" fill="currentColor"/>
 		</svg>
 	),
 	'Student History': (

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -13,6 +13,7 @@ import UserInfoDisplay from '../utility/UserInfoDisplay'; // <-- User info from 
 import About from '../about/About'; // <-- ADDED: Import About component for Help tab
 import { HISTORY_SHEET, MASTER_LIST_SHEET } from '../../../../shared/constants.js';
 import { getWorkbookUsers } from '../../services/workbookUsers.js';
+import { importHistoryFromLdaSheets, loadLdaHistory, historyToCsv } from '../createLDA/riskIndex.js';
 
 const SUMMARY_BRAND = '#145F82';
 
@@ -231,6 +232,10 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 	// Create Student History sheet state
 	const [creatingHistorySheet, setCreatingHistorySheet] = useState(false);
 
+	// Risk Index: LDA history import/download state
+	const [importingLdaHistory, setImportingLdaHistory] = useState(false);
+	const [downloadingLdaHistory, setDownloadingLdaHistory] = useState(false);
+
 	// Default headers for a freshly-created Student History sheet. Each name is
 	// a canonical alias from shared/columnAliases.js so the existing add/edit/
 	// delete-comment flows resolve them via canonicalHeaderMap.
@@ -441,6 +446,59 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 			alert(err.message || 'Failed to create Student History sheet');
 		} finally {
 			setCreatingHistorySheet(false);
+		}
+	};
+
+	// Risk Index: backfill LDAHistory from previous "LDA M-D-YYYY" sheets
+	const importLdaHistory = async () => {
+		if (importingLdaHistory) return;
+		setImportingLdaHistory(true);
+		try {
+			const result = await importHistoryFromLdaSheets();
+			if (result.scanned === 0) {
+				alert('No previous LDA sheets found. This looks for sheets named like "LDA 7-21-2026".');
+			} else {
+				const parts = [`Scanned ${result.scanned} LDA sheet${result.scanned === 1 ? '' : 's'}.`];
+				parts.push(result.added.length > 0
+					? `Imported ${result.added.length} day${result.added.length === 1 ? '' : 's'} of history.`
+					: 'Nothing new to import.');
+				if (result.skipped.length > 0) parts.push(`${result.skipped.length} already in history (left untouched).`);
+				if (result.unreadable.length > 0) parts.push(`Skipped unreadable: ${result.unreadable.join(', ')}.`);
+				alert(parts.join('\n'));
+			}
+		} catch (err) {
+			console.error('Failed to import LDA history:', err);
+			alert(err.message || 'Failed to import LDA history');
+		} finally {
+			setImportingLdaHistory(false);
+		}
+	};
+
+	// Risk Index: download the saved LDA history as CSV
+	const downloadLdaHistory = () => {
+		if (downloadingLdaHistory) return;
+		setDownloadingLdaHistory(true);
+		try {
+			const history = loadLdaHistory();
+			const dayCount = Object.keys((history && history.days) || {}).length;
+			if (dayCount === 0) {
+				alert('No LDA history saved yet. It builds up as LDA sheets are created, or use Import Past Reports.');
+				return;
+			}
+			const blob = new Blob([historyToCsv(history)], { type: 'text/csv;charset=utf-8;' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = 'LDA History.csv';
+			document.body.appendChild(a);
+			a.click();
+			document.body.removeChild(a);
+			URL.revokeObjectURL(url);
+		} catch (err) {
+			console.error('Failed to download LDA history:', err);
+			alert(err.message || 'Failed to download LDA history');
+		} finally {
+			setDownloadingLdaHistory(false);
 		}
 	};
 
@@ -805,38 +863,83 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 							}
 
 							if (setting.type === 'action') {
-								const isDownloading = setting.id === 'downloadHistoryCsv' && downloadingCsv;
-								const isCreating = setting.id === 'createHistorySheet' && creatingHistorySheet;
+								const plusIcon = (
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+										<line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+										<line x1="5" y1="12" x2="19" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
+									</svg>
+								);
+								const downloadIcon = (
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+										<polyline points="7 10 12 15 17 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+										<line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+									</svg>
+								);
+								const importIcon = (
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+										<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+										<polyline points="7 8 12 3 17 8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+										<line x1="12" y1="3" x2="12" y2="15" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+									</svg>
+								);
+
 								// historyCommentCount is null both before the workbook summary loads and
 								// when the History sheet doesn't exist — either way, there's nothing to
-								// download yet, so disable the button.
+								// download yet, so disable the button. Inverse for Create: greyed out when
+								// the sheet already exists, or while the workbook summary is still
+								// resolving so we don't race a duplicate.
 								const noHistorySheet = setting.id === 'downloadHistoryCsv' && historyCommentCount == null;
-								// Inverse for Create: greyed out when the sheet already exists, or while
-								// the workbook summary is still resolving so we don't race a duplicate.
 								const historySheetExists = setting.id === 'createHistorySheet' && (historyCommentCount != null || summaryLoading);
-								const isDisabled = isDownloading || isCreating || noHistorySheet || historySheetExists;
-								const isCreate = setting.id === 'createHistorySheet';
-								const greyedReason = noHistorySheet
-									? `No "${HISTORY_SHEET}" sheet found — nothing to download`
-									: (historySheetExists && historyCommentCount != null
-										? `"${HISTORY_SHEET}" sheet already exists`
-										: undefined);
+								const actions = {
+									createHistorySheet: {
+										run: createHistorySheet,
+										busy: creatingHistorySheet,
+										icon: plusIcon,
+										idle: 'Create',
+										busyLabel: 'Creating...',
+										greyed: historySheetExists,
+										greyedReason: historyCommentCount != null ? `"${HISTORY_SHEET}" sheet already exists` : undefined,
+									},
+									downloadHistoryCsv: {
+										run: downloadHistoryCsv,
+										busy: downloadingCsv,
+										icon: downloadIcon,
+										idle: 'Download',
+										busyLabel: 'Downloading...',
+										greyed: noHistorySheet,
+										greyedReason: noHistorySheet ? `No "${HISTORY_SHEET}" sheet found — nothing to download` : undefined,
+									},
+									importLdaHistory: {
+										run: importLdaHistory,
+										busy: importingLdaHistory,
+										icon: importIcon,
+										idle: 'Import',
+										busyLabel: 'Importing...',
+									},
+									downloadLdaHistory: {
+										run: downloadLdaHistory,
+										busy: downloadingLdaHistory,
+										icon: downloadIcon,
+										idle: 'Download',
+										busyLabel: 'Downloading...',
+									},
+								};
+								const action = actions[setting.id];
+								if (!action) return null;
+								const isDisabled = action.busy || !!action.greyed;
 								return (
 									<button
-										onClick={() => {
-											if (isDisabled) return;
-											if (setting.id === 'downloadHistoryCsv') downloadHistoryCsv();
-											else if (setting.id === 'createHistorySheet') createHistorySheet();
-										}}
+										onClick={() => { if (!isDisabled) action.run(); }}
 										disabled={isDisabled}
-										title={greyedReason}
+										title={action.greyedReason}
 										style={{
 											padding: '6px 10px',
 											borderRadius: 6,
 											background: isDisabled ? '#e5e7eb' : '#f3f4f6',
 											border: '1px solid #e6e7eb',
 											cursor: isDisabled ? 'not-allowed' : 'pointer',
-											color: (noHistorySheet || historySheetExists) ? '#9ca3af' : undefined,
+											color: action.greyed ? '#9ca3af' : undefined,
 											display: 'inline-flex',
 											alignItems: 'center',
 											gap: 6,
@@ -844,23 +947,8 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 										}}
 										aria-label={setting.label}
 									>
-										{isCreate ? (
-											/* plus icon */
-											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-												<line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
-												<line x1="5" y1="12" x2="19" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/>
-											</svg>
-										) : (
-											/* download icon */
-											<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-												<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-												<polyline points="7 10 12 15 17 10" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-												<line x1="12" y1="15" x2="12" y2="3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
-											</svg>
-										)}
-										{isCreate
-											? (isCreating ? 'Creating...' : 'Create')
-											: (isDownloading ? 'Downloading...' : 'Download')}
+										{action.icon}
+										{action.busy ? action.busyLabel : action.idle}
 									</button>
 								);
 							}


### PR DESCRIPTION
…ownload

The Create LDA page now surfaces only an on/off Risk Index toggle, placed in the Inclusions sub-view alongside the other inclusion toggles. All configuration lives in a new Risk Index section on the Settings taskpane:

- Track Risk Index, Risk Threshold, and RI Column as schema-driven rows, stored as flat workbookSettings keys (riskIndexEnabled, riskIndexThreshold, riskIndexShowColumn) like the other LDA settings
- Import Past Reports: scans previous "LDA M-D-YYYY" sheets (including "(2)" re-run suffixes) and backfills LDAHistory from them; dates that already have a real snapshot are never overwritten
- Download History: exports the saved history as a CSV (Date, SyStudentID, LDA, Days Out)

The Settings action-row renderer is generalized to a per-id config map so new actions no longer special-case each other's disable logic.


Claude-Session: https://claude.ai/code/session_01TfXnnBXcwpXuxKwv5oMwo5