### PR TITLE
Add import modal for LDA history: scan workbook or upload CSV/Excel

### DIFF
--- a/react/src/components/createLDA/__tests__/riskIndex.test.js
+++ b/react/src/components/createLDA/__tests__/riskIndex.test.js
@@ -13,6 +13,9 @@ import {
     resolveSnapshotIndices,
     mergeImportedDays,
     historyToCsv,
+    parseCsv,
+    excelCellToValue,
+    rowsToImportedDays,
 } from '../riskIndex.js';
 
 describe('sanitizeRiskIndexSettings', () => {
@@ -322,5 +325,89 @@ describe('historyToCsv', () => {
     it('returns just the header for empty history', () => {
         expect(historyToCsv(undefined)).toBe('Date,SyStudentID,LDA,Days Out');
         expect(historyToCsv({ version: 1, days: {} })).toBe('Date,SyStudentID,LDA,Days Out');
+    });
+});
+
+describe('parseCsv', () => {
+    it('parses plain rows', () => {
+        expect(parseCsv('a,b,c\n1,2,3')).toEqual([['a', 'b', 'c'], ['1', '2', '3']]);
+    });
+
+    it('handles quoted fields, escaped quotes, and embedded delimiters', () => {
+        expect(parseCsv('"a,b","x""y",plain\n1,2,3')).toEqual([['a,b', 'x"y', 'plain'], ['1', '2', '3']]);
+        expect(parseCsv('"line\nbreak",2')).toEqual([['line\nbreak', '2']]);
+    });
+
+    it('handles CRLF and trailing newlines', () => {
+        expect(parseCsv('a,b\r\n1,2\r\n')).toEqual([['a', 'b'], ['1', '2']]);
+    });
+
+    it('drops fully empty rows', () => {
+        expect(parseCsv('a,b\n\n1,2\n,\n')).toEqual([['a', 'b'], ['1', '2']]);
+    });
+});
+
+describe('excelCellToValue', () => {
+    it('passes through primitives and Dates', () => {
+        expect(excelCellToValue('x')).toBe('x');
+        expect(excelCellToValue(14)).toBe(14);
+        const d = new Date(Date.UTC(2026, 6, 21));
+        expect(excelCellToValue(d)).toBe(d);
+        expect(excelCellToValue(null)).toBe('');
+        expect(excelCellToValue(undefined)).toBe('');
+    });
+
+    it('unwraps rich text, formula results, and hyperlinks', () => {
+        expect(excelCellToValue({ richText: [{ text: 'Hello ' }, { text: 'World' }] })).toBe('Hello World');
+        expect(excelCellToValue({ formula: 'A1+A2', result: 14 })).toBe(14);
+        expect(excelCellToValue({ text: 'Link', hyperlink: 'https://x' })).toBe('Link');
+        expect(excelCellToValue({ hyperlink: 'https://x' })).toBe('https://x');
+    });
+});
+
+describe('rowsToImportedDays', () => {
+    const header = ['Date', 'SyStudentID', 'LDA', 'Days Out'];
+
+    it('converts the Download History layout back into day snapshots', () => {
+        const { days, rows, skippedRows } = rowsToImportedDays([
+            header,
+            ['2026-07-14', '10', '2026-07-01', '13'],
+            ['2026-07-14', '20', '', '5'],
+            ['2026-07-21', '10', '2026-07-07', '14'],
+        ]);
+        expect(rows).toBe(3);
+        expect(skippedRows).toBe(0);
+        expect(days).toEqual({
+            '2026-07-14': { '10': { lda: '2026-07-01', daysOut: 13 }, '20': { lda: null, daysOut: 5 } },
+            '2026-07-21': { '10': { lda: '2026-07-07', daysOut: 14 } },
+        });
+    });
+
+    it('accepts alias headers, slash dates, numeric ids, and Date objects', () => {
+        const { days } = rowsToImportedDays([
+            ['date', 'Student ID', 'Last Date of Attendance', 'days out'],
+            ['7/14/2026', 10, new Date(Date.UTC(2026, 6, 1)), 13],
+        ]);
+        expect(days['2026-07-14']['10']).toEqual({ lda: '2026-07-01', daysOut: 13 });
+    });
+
+    it('counts unusable rows as skipped', () => {
+        const { days, rows, skippedRows } = rowsToImportedDays([
+            header,
+            ['not a date', '10', '', '13'],
+            ['2026-07-14', '', '', '13'],
+            ['2026-07-14', '10', '', 'n/a'],
+            ['2026-07-14', '10', '', '13'],
+        ]);
+        expect(rows).toBe(1);
+        expect(skippedRows).toBe(3);
+        expect(Object.keys(days)).toEqual(['2026-07-14']);
+    });
+
+    it('throws on missing required columns or no usable rows', () => {
+        expect(() => rowsToImportedDays([['Foo', 'Bar'], ['1', '2']])).toThrow(/Missing required/);
+        expect(() => rowsToImportedDays([header])).toThrow(/no data rows/);
+        expect(() => rowsToImportedDays([header, ['bad', '', '', '']])).toThrow(/No usable rows/);
+        expect(() => rowsToImportedDays(null)).toThrow(/no data rows/);
     });
 });

--- a/react/src/components/createLDA/riskIndex.js
+++ b/react/src/components/createLDA/riskIndex.js
@@ -53,6 +53,11 @@ export function todayKey(date = new Date()) {
  */
 export function normalizeLdaValue(val) {
     if (val === null || val === undefined || val === '') return null;
+    if (val instanceof Date) {
+        // ExcelJS parses xlsx date cells as UTC-midnight Dates.
+        if (isNaN(val.getTime())) return null;
+        return `${val.getUTCFullYear()}-${pad2(val.getUTCMonth() + 1)}-${pad2(val.getUTCDate())}`;
+    }
     if (typeof val === 'number') {
         if (val < 20000 || val > 80000) return String(val);
         const d = new Date(Math.round((val - 25569) * 86400000));
@@ -198,6 +203,127 @@ export function mergeImportedDays(history, importedDays) {
     return { history: { version: 1, days }, added: added.sort(), skipped: skipped.sort() };
 }
 
+/**
+ * Minimal quote-aware CSV parser (handles quoted fields, escaped quotes, and
+ * newlines inside quotes). Returns an array of string rows.
+ */
+export function parseCsv(text) {
+    const rows = [];
+    let row = [];
+    let field = '';
+    let inQuotes = false;
+    const src = String(text ?? '');
+    for (let i = 0; i < src.length; i++) {
+        const ch = src[i];
+        if (inQuotes) {
+            if (ch === '"') {
+                if (src[i + 1] === '"') { field += '"'; i++; }
+                else inQuotes = false;
+            } else {
+                field += ch;
+            }
+        } else if (ch === '"') {
+            inQuotes = true;
+        } else if (ch === ',') {
+            row.push(field);
+            field = '';
+        } else if (ch === '\n' || ch === '\r') {
+            if (ch === '\r' && src[i + 1] === '\n') i++;
+            row.push(field);
+            field = '';
+            rows.push(row);
+            row = [];
+        } else {
+            field += ch;
+        }
+    }
+    if (field !== '' || row.length > 0) {
+        row.push(field);
+        rows.push(row);
+    }
+    // Drop fully-empty trailing rows (common with trailing newlines).
+    return rows.filter(r => r.some(c => String(c).trim() !== ''));
+}
+
+/**
+ * Unwrap an ExcelJS cell value (rich text, hyperlink, formula result, Date)
+ * into a plain value usable by rowsToImportedDays.
+ */
+export function excelCellToValue(v) {
+    if (v === null || v === undefined) return '';
+    if (v instanceof Date) return v;
+    if (typeof v === 'object') {
+        if (Array.isArray(v.richText)) return v.richText.map(t => t && t.text ? t.text : '').join('');
+        if (v.result !== undefined && v.result !== null) return excelCellToValue(v.result);
+        if (v.text !== undefined) return excelCellToValue(v.text);
+        if (v.hyperlink !== undefined) return String(v.hyperlink);
+        return '';
+    }
+    return v;
+}
+
+const DATE_COLUMN_ALIASES = ['date', 'snapshot date', 'day', 'timestamp'];
+
+/**
+ * Convert a header + data row matrix (from an uploaded CSV or Excel file) into
+ * per-day snapshots, matching the Download History layout: Date, SyStudentID,
+ * LDA, Days Out — columns resolved by alias, extra columns ignored. Rows
+ * without a parseable date, an id, or a numeric Days Out are counted as
+ * skipped. Throws when the required columns can't be found at all.
+ * @returns {{ days: Object, rows: number, skippedRows: number }}
+ */
+export function rowsToImportedDays(rows) {
+    if (!Array.isArray(rows) || rows.length < 2) {
+        throw new Error('File has no data rows.');
+    }
+    const headers = rows[0];
+    const normalized = headers.map(normalizeHeader);
+    const dateIdx = findColumnIndex(normalized, DATE_COLUMN_ALIASES);
+    const { idIdx, ldaIdx, daysOutIdx } = resolveSnapshotIndices(headers);
+    const missing = [];
+    if (dateIdx === -1) missing.push('Date');
+    if (idIdx === -1) missing.push('SyStudentID');
+    if (daysOutIdx === -1) missing.push('Days Out');
+    if (missing.length > 0) {
+        throw new Error(`Missing required column${missing.length === 1 ? '' : 's'}: ${missing.join(', ')}. Expected the Download History layout (Date, SyStudentID, LDA, Days Out).`);
+    }
+
+    const days = {};
+    let imported = 0;
+    let skippedRows = 0;
+    for (let i = 1; i < rows.length; i++) {
+        const row = rows[i] || [];
+        const dateKey = normalizeLdaValue(row[dateIdx]);
+        const rawId = row[idIdx];
+        const id = (rawId === null || rawId === undefined) ? '' : String(rawId).trim();
+        const daysOut = Number(row[daysOutIdx]);
+        if (!dateKey || !/^\d{4}-\d{2}-\d{2}$/.test(dateKey) || !id || !Number.isFinite(daysOut)) {
+            skippedRows++;
+            continue;
+        }
+        (days[dateKey] ||= {})[id] = {
+            lda: (ldaIdx !== -1) ? normalizeLdaValue(row[ldaIdx]) : null,
+            daysOut,
+        };
+        imported++;
+    }
+    if (imported === 0) {
+        throw new Error('No usable rows found — check the Date, SyStudentID, and Days Out values.');
+    }
+    return { days, rows: imported, skippedRows };
+}
+
+/**
+ * Merge already-parsed day snapshots into the stored history (existing dates
+ * always win) and persist when anything was added.
+ * @returns {{ added: string[], skipped: string[] }}
+ */
+export function importDaysIntoHistory(importedDays) {
+    const { history, added, skipped } = mergeImportedDays(loadLdaHistory(), importedDays);
+    if (added.length > 0) saveLdaHistory(history);
+    return { added, skipped };
+}
+
 /** Flatten the history into CSV (Date, SyStudentID, LDA, Days Out), sorted by date then id. */
 export function historyToCsv(history) {
     const escape = (v) => {
@@ -265,8 +391,7 @@ export async function importHistoryFromLdaSheets() {
             importedDays[target.dateKey] = snapshot;
         }
 
-        const { history, added, skipped } = mergeImportedDays(loadLdaHistory(), importedDays);
-        if (added.length > 0) saveLdaHistory(history);
+        const { added, skipped } = importDaysIntoHistory(importedDays);
         return { scanned: targets.length, added, skipped, unreadable };
     });
 }

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -164,7 +164,7 @@ export const defaultWorkbookSettings = [
 		type: 'action',
 		defaultValue: null,
 		section: 'Risk Index',
-		description: 'Scan previous "LDA M-D-YYYY" sheets in this workbook and backfill the history from them. Dates that already have a snapshot are left untouched.'
+		description: 'Backfill the history by scanning previous "LDA M-D-YYYY" sheets in this workbook, or by uploading a CSV/Excel file. Dates that already have a snapshot are left untouched.'
 	},
 	{
 		id: 'downloadLdaHistory',

--- a/react/src/components/settings/RiskIndexImportModal.jsx
+++ b/react/src/components/settings/RiskIndexImportModal.jsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect } from 'react';
+import { FileSearch, Upload, Loader2 } from 'lucide-react';
+import ExcelJS from 'exceljs';
+import {
+    importHistoryFromLdaSheets,
+    parseCsv,
+    excelCellToValue,
+    rowsToImportedDays,
+    importDaysIntoHistory,
+} from '../createLDA/riskIndex.js';
+
+// Import LDA history either by scanning the workbook's previous "LDA M-D-YYYY"
+// sheets or by uploading a CSV/Excel file in the Download History layout
+// (Date, SyStudentID, LDA, Days Out). Both paths merge at the day level and
+// never overwrite dates that already have a snapshot.
+export default function RiskIndexImportModal({ isOpen, onClose }) {
+    const [busy, setBusy] = useState(null); // null | 'scan' | 'file'
+    const [result, setResult] = useState(null); // { lines: string[] }
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        if (!isOpen) return;
+        setBusy(null);
+        setResult(null);
+        setError('');
+    }, [isOpen]);
+
+    const describeMerge = ({ added, skipped }) => {
+        const lines = [];
+        lines.push(added.length > 0
+            ? `Imported ${added.length} day${added.length === 1 ? '' : 's'} of history (${added[0]} to ${added[added.length - 1]}).`
+            : 'Nothing new to import.');
+        if (skipped.length > 0) {
+            lines.push(`${skipped.length} day${skipped.length === 1 ? '' : 's'} already in history (left untouched).`);
+        }
+        return lines;
+    };
+
+    const handleScan = async () => {
+        if (busy) return;
+        setBusy('scan');
+        setError('');
+        setResult(null);
+        try {
+            const res = await importHistoryFromLdaSheets();
+            if (res.scanned === 0) {
+                setError('No previous LDA sheets found. This looks for sheets named like "LDA 7-21-2026".');
+                return;
+            }
+            const lines = [`Scanned ${res.scanned} LDA sheet${res.scanned === 1 ? '' : 's'}.`, ...describeMerge(res)];
+            if (res.unreadable.length > 0) lines.push(`Skipped unreadable: ${res.unreadable.join(', ')}.`);
+            setResult({ lines });
+        } catch (err) {
+            console.error('LDA history workbook scan failed:', err);
+            setError(err.message || 'Scan failed.');
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    const readFileRows = async (file) => {
+        const name = String(file.name || '').toLowerCase();
+        if (name.endsWith('.csv')) {
+            return parseCsv(await file.text());
+        }
+        if (name.endsWith('.xlsx') || name.endsWith('.xlsm') || name.endsWith('.xls')) {
+            const workbook = new ExcelJS.Workbook();
+            await workbook.xlsx.load(await file.arrayBuffer());
+            const sheet = workbook.worksheets[0];
+            if (!sheet) throw new Error('Workbook has no sheets.');
+            const rows = [];
+            sheet.eachRow({ includeEmpty: false }, (row) => {
+                // row.values is 1-indexed; slot 0 is always empty.
+                rows.push(row.values.slice(1).map(excelCellToValue));
+            });
+            return rows;
+        }
+        throw new Error('Unsupported file type — upload a .csv or .xlsx file.');
+    };
+
+    const handleFileSelect = async (e) => {
+        const file = e.target.files && e.target.files[0];
+        e.target.value = '';
+        if (!file || busy) return;
+        setBusy('file');
+        setError('');
+        setResult(null);
+        try {
+            const parsed = rowsToImportedDays(await readFileRows(file));
+            const merge = importDaysIntoHistory(parsed.days);
+            const lines = [`Read ${parsed.rows} row${parsed.rows === 1 ? '' : 's'} from "${file.name}".`, ...describeMerge(merge)];
+            if (parsed.skippedRows > 0) lines.push(`${parsed.skippedRows} row${parsed.skippedRows === 1 ? '' : 's'} skipped (missing date, ID, or Days Out).`);
+            setResult({ lines });
+        } catch (err) {
+            console.error('LDA history file import failed:', err);
+            setError(err.message || 'File import failed.');
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    if (!isOpen) return null;
+
+    const optionClass = 'w-full flex items-start gap-3 p-4 rounded-xl border border-gray-200 hover:border-[#145F82]/60 hover:bg-slate-50 transition-colors text-left disabled:opacity-60 disabled:cursor-not-allowed';
+
+    return (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md mx-4">
+                <div className="flex justify-between items-start mb-4">
+                    <div>
+                        <h3 className="text-lg font-semibold text-gray-800">Import LDA History</h3>
+                        <p className="text-xs text-gray-500 mt-0.5">
+                            Backfill the Risk Index history. Days that already have a snapshot are never overwritten.
+                        </p>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        aria-label="Close"
+                        className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+                    >
+                        &times;
+                    </button>
+                </div>
+
+                <div className="space-y-3">
+                    <button
+                        type="button"
+                        onClick={handleScan}
+                        disabled={!!busy}
+                        className={optionClass}
+                    >
+                        <span className="w-9 h-9 rounded-lg bg-[#145F82]/10 text-[#145F82] flex items-center justify-center shrink-0">
+                            {busy === 'scan' ? <Loader2 className="w-5 h-5 animate-spin" /> : <FileSearch className="w-5 h-5" />}
+                        </span>
+                        <span className="min-w-0">
+                            <span className="block text-sm font-semibold text-gray-800">
+                                {busy === 'scan' ? 'Scanning workbook…' : 'Scan Workbook'}
+                            </span>
+                            <span className="block text-xs text-gray-500 mt-0.5">
+                                Read previous LDA sheets in this workbook (named like "LDA 7-21-2026").
+                            </span>
+                        </span>
+                    </button>
+
+                    <label className={`${optionClass} ${busy ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}>
+                        <input
+                            type="file"
+                            accept=".csv,.xlsx,.xlsm,.xls"
+                            onChange={handleFileSelect}
+                            disabled={!!busy}
+                            className="hidden"
+                        />
+                        <span className="w-9 h-9 rounded-lg bg-[#145F82]/10 text-[#145F82] flex items-center justify-center shrink-0">
+                            {busy === 'file' ? <Loader2 className="w-5 h-5 animate-spin" /> : <Upload className="w-5 h-5" />}
+                        </span>
+                        <span className="min-w-0">
+                            <span className="block text-sm font-semibold text-gray-800">
+                                {busy === 'file' ? 'Importing file…' : 'Upload File'}
+                            </span>
+                            <span className="block text-xs text-gray-500 mt-0.5">
+                                Import a CSV or Excel file with Date, SyStudentID, LDA, and Days Out columns
+                                (the Download History format).
+                            </span>
+                        </span>
+                    </label>
+                </div>
+
+                {error && (
+                    <div className="mt-4 text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                        {error}
+                    </div>
+                )}
+                {result && (
+                    <div className="mt-4 text-sm text-emerald-800 bg-emerald-50 border border-emerald-100 rounded-lg px-3 py-2 space-y-1">
+                        {result.lines.map((line, i) => <div key={i}>{line}</div>)}
+                    </div>
+                )}
+
+                <div className="flex justify-end mt-5">
+                    <button
+                        onClick={onClose}
+                        className="px-4 py-2 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 text-sm"
+                    >
+                        Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -13,7 +13,8 @@ import UserInfoDisplay from '../utility/UserInfoDisplay'; // <-- User info from 
 import About from '../about/About'; // <-- ADDED: Import About component for Help tab
 import { HISTORY_SHEET, MASTER_LIST_SHEET } from '../../../../shared/constants.js';
 import { getWorkbookUsers } from '../../services/workbookUsers.js';
-import { importHistoryFromLdaSheets, loadLdaHistory, historyToCsv } from '../createLDA/riskIndex.js';
+import { loadLdaHistory, historyToCsv } from '../createLDA/riskIndex.js';
+import RiskIndexImportModal from './RiskIndexImportModal'; // <-- ADDED: Risk Index history import modal
 
 const SUMMARY_BRAND = '#145F82';
 
@@ -232,8 +233,8 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 	// Create Student History sheet state
 	const [creatingHistorySheet, setCreatingHistorySheet] = useState(false);
 
-	// Risk Index: LDA history import/download state
-	const [importingLdaHistory, setImportingLdaHistory] = useState(false);
+	// Risk Index: LDA history import modal + download state
+	const [riskImportModalOpen, setRiskImportModalOpen] = useState(false);
 	const [downloadingLdaHistory, setDownloadingLdaHistory] = useState(false);
 
 	// Default headers for a freshly-created Student History sheet. Each name is
@@ -446,31 +447,6 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 			alert(err.message || 'Failed to create Student History sheet');
 		} finally {
 			setCreatingHistorySheet(false);
-		}
-	};
-
-	// Risk Index: backfill LDAHistory from previous "LDA M-D-YYYY" sheets
-	const importLdaHistory = async () => {
-		if (importingLdaHistory) return;
-		setImportingLdaHistory(true);
-		try {
-			const result = await importHistoryFromLdaSheets();
-			if (result.scanned === 0) {
-				alert('No previous LDA sheets found. This looks for sheets named like "LDA 7-21-2026".');
-			} else {
-				const parts = [`Scanned ${result.scanned} LDA sheet${result.scanned === 1 ? '' : 's'}.`];
-				parts.push(result.added.length > 0
-					? `Imported ${result.added.length} day${result.added.length === 1 ? '' : 's'} of history.`
-					: 'Nothing new to import.');
-				if (result.skipped.length > 0) parts.push(`${result.skipped.length} already in history (left untouched).`);
-				if (result.unreadable.length > 0) parts.push(`Skipped unreadable: ${result.unreadable.join(', ')}.`);
-				alert(parts.join('\n'));
-			}
-		} catch (err) {
-			console.error('Failed to import LDA history:', err);
-			alert(err.message || 'Failed to import LDA history');
-		} finally {
-			setImportingLdaHistory(false);
 		}
 	};
 
@@ -911,8 +887,8 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 										greyedReason: noHistorySheet ? `No "${HISTORY_SHEET}" sheet found — nothing to download` : undefined,
 									},
 									importLdaHistory: {
-										run: importLdaHistory,
-										busy: importingLdaHistory,
+										run: () => setRiskImportModalOpen(true),
+										busy: false,
 										icon: importIcon,
 										idle: 'Import',
 										busyLabel: 'Importing...',
@@ -1270,6 +1246,11 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 					dncColor: workbookSettingsState.dncColor ?? '#f2bdbd',
 				}}
 				onChange={updateWorkbookSetting}
+			/>
+
+			<RiskIndexImportModal
+				isOpen={riskImportModalOpen}
+				onClose={() => setRiskImportModalOpen(false)}
 			/>
 		</div>
 	);


### PR DESCRIPTION
The Import Past Reports button on the Settings taskpane now opens a modal with two options instead of scanning immediately:

- Scan Workbook: the existing backfill from previous "LDA M-D-YYYY" sheets
- Upload File: read a .csv or .xlsx/.xlsm file in the Download History layout (Date, SyStudentID, LDA, Days Out — headers matched by alias, extra columns ignored), parsed with a quote-aware CSV parser or ExcelJS

Both paths merge at the day level and never overwrite dates that already have a snapshot; results (days imported / already present / rows skipped) are shown inline in the modal rather than via alert.


Claude-Session: https://claude.ai/code/session_01TfXnnBXcwpXuxKwv5oMwo5