### PR TITLE
Add At-Risk Students leaderboard card to the Risk Index settings page

### DIFF
--- a/react/src/components/createLDA/__tests__/riskIndex.test.js
+++ b/react/src/components/createLDA/__tests__/riskIndex.test.js
@@ -16,6 +16,7 @@ import {
     parseCsv,
     excelCellToValue,
     rowsToImportedDays,
+    buildRiskLeaderboard,
 } from '../riskIndex.js';
 
 describe('sanitizeRiskIndexSettings', () => {
@@ -409,5 +410,48 @@ describe('rowsToImportedDays', () => {
         expect(() => rowsToImportedDays([header])).toThrow(/no data rows/);
         expect(() => rowsToImportedDays([header, ['bad', '', '', '']])).toThrow(/No usable rows/);
         expect(() => rowsToImportedDays(null)).toThrow(/no data rows/);
+    });
+});
+
+describe('buildRiskLeaderboard', () => {
+    const master = [
+        ['SyStudentID', 'Student Name', 'Gender', 'Profile Picture', 'Days Out'],
+        [10, 'Zeta, Amy', 'Female', 'https://cdn.example/amy.jpg', 15],
+        [20, 'Alpha, Bob', 'Male', '', 3],
+        [30, 'Mid, Cara', '', 'not a url', 20],
+        [40, 'Zero, Dan', 'Male', '', 1],
+    ];
+
+    it('ranks students by count descending, excluding zero-count students', () => {
+        const counts = new Map([['10', 2], ['20', 2], ['30', 5]]);
+        const board = buildRiskLeaderboard(counts, master);
+        expect(board.map(s => s.id)).toEqual(['30', '20', '10']);
+        expect(board[0].count).toBe(5);
+        // ties broken by name: 'Alpha, Bob' before 'Zeta, Amy'
+        expect(board.slice(1).map(s => s.name)).toEqual(['Alpha, Bob', 'Zeta, Amy']);
+    });
+
+    it('drops ids that are no longer on the Master List', () => {
+        const counts = new Map([['10', 1], ['999', 4]]);
+        expect(buildRiskLeaderboard(counts, master).map(s => s.id)).toEqual(['10']);
+    });
+
+    it('only keeps http(s)/data profile picture values', () => {
+        const counts = new Map([['10', 1], ['30', 1]]);
+        const board = buildRiskLeaderboard(counts, master);
+        expect(board.find(s => s.id === '10').profilePicture).toBe('https://cdn.example/amy.jpg');
+        expect(board.find(s => s.id === '30').profilePicture).toBeNull();
+    });
+
+    it('carries gender for the avatar fallback', () => {
+        const counts = new Map([['10', 1]]);
+        expect(buildRiskLeaderboard(counts, master)[0].gender).toBe('Female');
+    });
+
+    it('returns empty for missing inputs or unusable master', () => {
+        expect(buildRiskLeaderboard(new Map(), master)).toEqual([]);
+        expect(buildRiskLeaderboard(new Map([['10', 1]]), null)).toEqual([]);
+        expect(buildRiskLeaderboard(new Map([['10', 1]]), [['No Id Col'], ['x']])).toEqual([]);
+        expect(buildRiskLeaderboard(null, master)).toEqual([]);
     });
 });

--- a/react/src/components/createLDA/riskIndex.js
+++ b/react/src/components/createLDA/riskIndex.js
@@ -17,7 +17,15 @@
 /* global Office, Excel */
 
 import { findColumnIndex, normalizeHeader } from '../../../../shared/excel-helpers.js';
-import { STUDENT_ID_ALIASES, STUDENT_NUMBER_ALIASES, LAST_LDA_ALIASES, DAYS_OUT_ALIASES } from '../../../../shared/columnAliases.js';
+import {
+    STUDENT_ID_ALIASES,
+    STUDENT_NUMBER_ALIASES,
+    LAST_LDA_ALIASES,
+    DAYS_OUT_ALIASES,
+    STUDENT_NAME_ALIASES,
+    GENDER_ALIASES,
+    PROFILE_PICTURE_ALIASES,
+} from '../../../../shared/columnAliases.js';
 
 export const LDA_HISTORY_KEY = 'LDAHistory';
 
@@ -394,6 +402,54 @@ export async function importHistoryFromLdaSheets() {
         const { added, skipped } = importDaysIntoHistory(importedDays);
         return { scanned: targets.length, added, skipped, unreadable };
     });
+}
+
+/**
+ * Join risk counts with the Master List into a ranked leaderboard.
+ * Only students with a count > 0 AND a current Master List row are included —
+ * ids missing from the master are treated as dropped and left off. Sorted by
+ * count descending, then name.
+ * @param {Map<string, number>} riskCounts - from countRiskEpisodes
+ * @param {Array<Array>} masterValues - Master List matrix (row 0 = headers)
+ * @returns {Array<{ id, name, gender, profilePicture, count }>}
+ */
+export function buildRiskLeaderboard(riskCounts, masterValues) {
+    if (!(riskCounts instanceof Map) || riskCounts.size === 0) return [];
+    if (!Array.isArray(masterValues) || masterValues.length < 2) return [];
+    const normalized = masterValues[0].map(normalizeHeader);
+    const sy = findColumnIndex(normalized, STUDENT_ID_ALIASES);
+    const idIdx = sy !== -1 ? sy : findColumnIndex(normalized, STUDENT_NUMBER_ALIASES);
+    if (idIdx === -1) return [];
+    const nameIdx = findColumnIndex(normalized, STUDENT_NAME_ALIASES);
+    const genderIdx = findColumnIndex(normalized, GENDER_ALIASES);
+    const pfpIdx = findColumnIndex(normalized, PROFILE_PICTURE_ALIASES);
+
+    const asUrl = (v) => {
+        const str = (v === null || v === undefined) ? '' : String(v).trim();
+        return (/^https?:\/\//i.test(str) || str.startsWith('data:image')) ? str : null;
+    };
+
+    const entries = [];
+    const seen = new Set();
+    for (let i = 1; i < masterValues.length; i++) {
+        const row = masterValues[i];
+        if (!row) continue;
+        const rawId = row[idIdx];
+        const id = (rawId === null || rawId === undefined) ? '' : String(rawId).trim();
+        if (!id || seen.has(id)) continue;
+        const count = riskCounts.get(id);
+        if (!count) continue;
+        seen.add(id);
+        entries.push({
+            id,
+            count,
+            name: (nameIdx !== -1) ? String(row[nameIdx] ?? '').trim() : '',
+            gender: (genderIdx !== -1) ? String(row[genderIdx] ?? '').trim() : '',
+            profilePicture: (pfpIdx !== -1) ? asUrl(row[pfpIdx]) : null,
+        });
+    }
+    entries.sort((a, b) => (b.count - a.count) || a.name.localeCompare(b.name));
+    return entries;
 }
 
 /** First matching count for any of the student's id variants (SyStudentId, Student Number). */

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -175,6 +175,14 @@ export const defaultWorkbookSettings = [
 		description: 'Download the saved LDA history (date, student ID, LDA, days out) as a CSV file.'
 	},
 	{
+		id: 'riskLeaderboard',
+		label: 'At-Risk Students',
+		type: 'riskleaderboard',
+		defaultValue: null,
+		section: 'Risk Index',
+		description: 'Students ranked by Risk Index, greatest first. Students no longer on the Master List are treated as dropped and hidden.'
+	},
+	{
 		id: 'powerAutomateUrl',
 		label: 'Power Automate',
 		type: 'powerautomate',

--- a/react/src/components/settings/RiskIndexLeaderboard.jsx
+++ b/react/src/components/settings/RiskIndexLeaderboard.jsx
@@ -1,0 +1,207 @@
+import React, { useState, useEffect } from 'react';
+import { User, RefreshCw } from 'lucide-react';
+import { formatName } from '../utility/Conversion';
+import { MASTER_LIST_SHEET } from '../../../../shared/constants.js';
+import {
+    getRiskIndexConfig,
+    loadLdaHistory,
+    countRiskEpisodes,
+    buildRiskLeaderboard,
+} from '../createLDA/riskIndex.js';
+
+/* global Excel */
+
+// Same gender-based avatar treatment as the student view header.
+const avatarBg = (gender) => {
+    const g = String(gender || '').toLowerCase();
+    if (g === 'male') return { background: '#1278FF', color: '#FFFFFF' };
+    if (g === 'female') return { background: '#ed72b5', color: '#FFFFFF' };
+    return { background: '#6b7280', color: '#FFFFFF' };
+};
+
+function RowAvatar({ student }) {
+    const [imageError, setImageError] = useState(false);
+    useEffect(() => { setImageError(false); }, [student.profilePicture]);
+
+    if (student.profilePicture && !imageError) {
+        return (
+            <img
+                src={student.profilePicture}
+                alt={student.name ? `${student.name} profile` : 'Student profile'}
+                onError={() => setImageError(true)}
+                style={{ width: 28, height: 28, borderRadius: '50%', objectFit: 'cover', display: 'block' }}
+            />
+        );
+    }
+    return (
+        <div style={{
+            width: 28, height: 28, borderRadius: '50%',
+            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+            ...avatarBg(student.gender),
+        }}>
+            <User size={16} strokeWidth={2} aria-hidden="true" />
+        </div>
+    );
+}
+
+/**
+ * Ranked list of students by Risk Index (times they hit the risk threshold),
+ * greatest first. Students with no hits are excluded, and so are ids no longer
+ * on the Master List — those are assumed dropped.
+ */
+export default function RiskIndexLeaderboard({ refreshToken }) {
+    const [students, setStudents] = useState(null); // null = loading
+    const [threshold, setThreshold] = useState(null);
+    const [error, setError] = useState('');
+
+    const load = async () => {
+        setError('');
+        try {
+            const cfg = getRiskIndexConfig();
+            setThreshold(cfg.threshold);
+            const counts = countRiskEpisodes(loadLdaHistory(), cfg.threshold);
+            if (counts.size === 0) {
+                setStudents([]);
+                return;
+            }
+            if (typeof window === 'undefined' || !window.Excel || !Excel.run) {
+                throw new Error('Excel API not available');
+            }
+            const masterValues = await Excel.run(async (context) => {
+                const sheet = context.workbook.worksheets.getItemOrNullObject(MASTER_LIST_SHEET);
+                await context.sync();
+                if (sheet.isNullObject) return null;
+                const used = sheet.getUsedRangeOrNullObject();
+                used.load('values');
+                await context.sync();
+                return (used.isNullObject || !used.values) ? null : used.values;
+            });
+            if (!masterValues) {
+                throw new Error(`No "${MASTER_LIST_SHEET}" sheet found — names can't be looked up.`);
+            }
+            setStudents(buildRiskLeaderboard(counts, masterValues));
+        } catch (err) {
+            console.error('Failed to load Risk Index leaderboard:', err);
+            setError(err.message || 'Failed to load at-risk students');
+            setStudents([]);
+        }
+    };
+
+    useEffect(() => {
+        setStudents(null);
+        load();
+        // Reload on mount and whenever the parent signals fresh history
+        // (e.g. the import modal just closed).
+    }, [refreshToken]);
+
+    const loading = students === null;
+
+    return (
+        <div style={{ display: 'grid', gap: 8, width: '100%' }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', padding: '0 2px' }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                    <div style={{ fontSize: 14, fontWeight: 600 }}>At-Risk Students</div>
+                    {threshold != null && (
+                        <div style={{ fontSize: 11, color: '#9ca3af' }} title={`Times each student hit ${threshold}+ days out`}>
+                            hit {threshold}+ days out
+                        </div>
+                    )}
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    {!loading && students.length > 0 && (
+                        <div style={{ fontSize: 12, color: '#6b7280' }}>
+                            {students.length} {students.length === 1 ? 'student' : 'students'}
+                        </div>
+                    )}
+                    <button
+                        type="button"
+                        onClick={() => { if (!loading) { setStudents(null); load(); } }}
+                        title="Refresh"
+                        aria-label="Refresh at-risk students"
+                        style={{
+                            border: 'none', background: 'transparent', color: '#6b7280',
+                            cursor: 'pointer', padding: 2, display: 'inline-flex', alignItems: 'center',
+                        }}
+                    >
+                        <RefreshCw size={13} className={loading ? 'animate-spin' : undefined} />
+                    </button>
+                </div>
+            </div>
+
+            {loading ? (
+                <div style={{
+                    padding: '12px 14px', border: '1px dashed #e5e7eb', borderRadius: 8,
+                    background: '#fff', color: '#6b7280', fontSize: 13, textAlign: 'center',
+                }}>
+                    Loading…
+                </div>
+            ) : error ? (
+                <div style={{
+                    padding: '12px 14px', border: '1px solid #fecaca', borderRadius: 8,
+                    background: '#fef2f2', color: '#b91c1c', fontSize: 13,
+                }}>
+                    {error}
+                </div>
+            ) : students.length === 0 ? (
+                <div style={{
+                    padding: '12px 14px', border: '1px dashed #e5e7eb', borderRadius: 8,
+                    background: '#fff', color: '#6b7280', fontSize: 13, textAlign: 'center',
+                }}>
+                    No students have hit the risk threshold yet. History builds as LDA sheets are created,
+                    or use Import Past Reports.
+                </div>
+            ) : (
+                <ul style={{
+                    listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 6,
+                    maxHeight: 320, overflowY: 'auto',
+                }}>
+                    {students.map((s, i) => {
+                        const displayName = s.name
+                            ? (s.name.includes(',') ? formatName(s.name) : s.name)
+                            : `Student ${s.id}`;
+                        return (
+                            <li
+                                key={s.id}
+                                style={{
+                                    display: 'grid',
+                                    gridTemplateColumns: '20px 28px 1fr auto',
+                                    alignItems: 'center',
+                                    gap: 10,
+                                    padding: '8px 12px',
+                                    background: '#fff',
+                                    border: '1px solid #e5e7eb',
+                                    borderRadius: 8,
+                                }}
+                            >
+                                <div style={{ fontSize: 11, fontWeight: 600, color: '#9ca3af', textAlign: 'right' }}>
+                                    {i + 1}
+                                </div>
+                                <RowAvatar student={s} />
+                                <div style={{ minWidth: 0, display: 'grid', gap: 1 }}>
+                                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 13, fontWeight: 500 }}>
+                                        {displayName}
+                                    </div>
+                                    <div style={{ fontSize: 11, color: '#6b7280' }}>
+                                        ID {s.id}
+                                    </div>
+                                </div>
+                                <div
+                                    title={`Hit ${threshold}+ days out ${s.count} ${s.count === 1 ? 'time' : 'times'}`}
+                                    style={{
+                                        minWidth: 26, height: 22, padding: '0 8px', borderRadius: 9999,
+                                        background: s.count >= 3 ? '#991b1b' : s.count === 2 ? '#dc2626' : '#fecaca',
+                                        color: s.count >= 2 ? '#ffffff' : '#991b1b',
+                                        display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                                        fontSize: 12, fontWeight: 700, justifySelf: 'end',
+                                    }}
+                                >
+                                    {s.count}
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -15,6 +15,7 @@ import { HISTORY_SHEET, MASTER_LIST_SHEET } from '../../../../shared/constants.j
 import { getWorkbookUsers } from '../../services/workbookUsers.js';
 import { loadLdaHistory, historyToCsv } from '../createLDA/riskIndex.js';
 import RiskIndexImportModal from './RiskIndexImportModal'; // <-- ADDED: Risk Index history import modal
+import RiskIndexLeaderboard from './RiskIndexLeaderboard'; // <-- ADDED: ranked at-risk students card
 
 const SUMMARY_BRAND = '#145F82';
 
@@ -669,6 +670,11 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 			// Custom full-width row for the workbook user roster.
 			if (setting.type === 'userslist') {
 				return <UsersList key={setting.id} />;
+			}
+			// Custom full-width row: students ranked by Risk Index. Keyed off the
+			// import modal's open state so closing it reloads fresh history.
+			if (setting.type === 'riskleaderboard') {
+				return <RiskIndexLeaderboard key={setting.id} refreshToken={riskImportModalOpen} />;
 			}
 			return (
 				<div key={setting.id} style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center', gap: 8, width: '100%', boxSizing: 'border-box' }}>

--- a/shared/columnAliases.js
+++ b/shared/columnAliases.js
@@ -27,6 +27,8 @@ export const STUDENT_NUMBER_ALIASES = ['student number', 'student identifier'];
 
 export const GENDER_ALIASES = ['gender'];
 
+export const PROFILE_PICTURE_ALIASES = ['profile picture', 'photo', 'avatar'];
+
 // ===== Outreach / Status =====
 // "comments"/"notes"/"comment" are also Outreach aliases — workbooks vary on
 // what they call this column. Note these overlap with COMMENT_ALIASES (used


### PR DESCRIPTION
New card on the Settings taskpane's Risk Index page listing students ranked by Risk Index, greatest first, in a scrollable container. Zero-count students are excluded, and ids no longer on the Master List are treated as dropped and hidden. Each row shows rank, avatar, name (formatted from "Last, First"), SyStudentID, and a count pill that darkens with severity.

Names, gender, and profile pictures are looked up from the Master List; rows without a valid picture URL fall back to the student view's avatar treatment (gender-colored circle with a User icon). The card refreshes on demand and automatically when the import modal closes.

PROFILE_PICTURE_ALIASES joins shared/columnAliases.js so the lookup uses the shared alias source instead of duplicating the student view's list.


Claude-Session: https://claude.ai/code/session_01TfXnnBXcwpXuxKwv5oMwo5