### PR TITLE
Standardize GitHub organization name casing to Northbridge-University

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ flows by sideloading the manifest into Excel.
 
 Two environments:
 
-- **Prod — GitHub Pages.** `https://northbridge-university.github.io/Student-Retention-Add-in/`
+- **Prod — GitHub Pages.** `https://Northbridge-University.github.io/Student-Retention-Add-in/`
   Serves the `react/dist/` committed on `main`. Sideload `manifest.xml`.
 - **Staging — `staging` branch via Vercel.**
-  `https://student-retention-kit-git-staging-northbridge-university.vercel.app/`
+  `https://student-retention-kit-git-staging-Northbridge-University.vercel.app/`
   Auto-deployed by Vercel on every push to `staging` (build config in
   `vercel.json`). Sideload `manifest.staging.xml`. Use this for full-deploy
   testing before promoting to prod.
@@ -118,7 +118,7 @@ feature-branch → staging (test on Vercel) → main (prod on GitHub Pages)
 ```
 
 Feature branches pushed to GitHub also get automatic Vercel preview URLs
-(pattern: `student-retention-kit-git-<branch>-northbridge-university.vercel.app`), but those
+(pattern: `student-retention-kit-git-<branch>-Northbridge-University.vercel.app`), but those
 hosts aren't registered in Azure AD by default — for full SSO-enabled testing,
 merge into `staging` and use `manifest.staging.xml`.
 
@@ -147,6 +147,6 @@ Each environment's host needs **two** entries on the Azure AD app registration
 2. A **redirect URI** (`https://<host>/react/dist/index.html`) of type SPA under
    "Authentication"
 
-Currently registered: `northbridge-university.github.io` (prod) and
-`student-retention-kit-git-staging-northbridge-university.vercel.app` (staging). New
+Currently registered: `Northbridge-University.github.io` (prod) and
+`student-retention-kit-git-staging-Northbridge-University.vercel.app` (staging). New
 environments require the same two-entry add.

--- a/commands/src/master-list-import.js
+++ b/commands/src/master-list-import.js
@@ -205,7 +205,7 @@ async function importMissingAssignments(studentsWithAssignments) {
  */
 function showMissingMasterListDialog(payload) {
     // Resolve relative to the runtime page (commands.html) so the dialog works
-    // on both prod (northbridge-university.github.io) and staging (Vercel) without needing a
+    // on both prod (Northbridge-University.github.io) and staging (Vercel) without needing a
     // host-specific URL — both AppDomains lists allow same-origin URLs.
     const dialogUrl = new URL('missing-masterlist-dialog.html', window.location.href).href;
 

--- a/documentation/MICROSOFT_SSO_SETUP.md
+++ b/documentation/MICROSOFT_SSO_SETUP.md
@@ -74,7 +74,7 @@ To enable Microsoft SSO, you need to register an app in Azure AD:
 3. Select **"Single-page application"**
 4. Add these redirect URIs:
    ```
-   https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/index.html
+   https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/index.html
    https://localhost:3000
    ```
 5. Check these boxes under **Implicit grant and hybrid flows**:
@@ -105,7 +105,7 @@ To enable Microsoft SSO, you need to register an app in Azure AD:
   <!-- WebApplicationInfo MUST be the last child of VersionOverrides -->
   <WebApplicationInfo>
     <Id>YOUR_CLIENT_ID_HERE</Id>
-    <Resource>api://northbridge-university.github.io/YOUR_CLIENT_ID_HERE</Resource>
+    <Resource>api://Northbridge-University.github.io/YOUR_CLIENT_ID_HERE</Resource>
     <Scopes>
       <Scope>openid</Scope>
       <Scope>profile</Scope>
@@ -128,7 +128,7 @@ To enable Microsoft SSO, you need to register an app in Azure AD:
 
 1. In your app registration, go to **"Expose an API"**
 2. Click **"+ Add a scope"**
-3. For Application ID URI, use: `api://northbridge-university.github.io/YOUR_CLIENT_ID_HERE`
+3. For Application ID URI, use: `api://Northbridge-University.github.io/YOUR_CLIENT_ID_HERE`
 4. Click **Save and continue**
 5. Fill in the scope details:
    - **Scope name**: `access_as_user`

--- a/manifest.xml
+++ b/manifest.xml
@@ -7,17 +7,17 @@
   <DisplayName DefaultValue="Student Retention Add-in"/>
   <Description DefaultValue="An add-in for tracking student retention tasks."/>
   
-  <IconUrl DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/icon-32.png"/>
+  <IconUrl DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/icon-32.png"/>
   
   <SupportUrl DefaultValue="https://github.com/Northbridge-University/Student-Retention-Add-in"/>
   <AppDomains>
-    <AppDomain>https://northbridge-university.github.io</AppDomain>
+    <AppDomain>https://Northbridge-University.github.io</AppDomain>
   </AppDomains>
   <Hosts>
     <Host Name="Workbook"/>
   </Hosts>
   <DefaultSettings>
-    <SourceLocation DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/index.html"/>
+    <SourceLocation DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/index.html"/>
     <RequestedWidth>450</RequestedWidth>
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
@@ -168,33 +168,33 @@
     </Hosts>
     <Resources>
       <bt:Images>
-        <bt:Image id="Icon.16x16" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/icon-16.png"/>
-        <bt:Image id="Icon.32x32" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/icon-32.png"/>
-        <bt:Image id="Icon.80x80" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/icon-80.png"/>
-        <bt:Image id="CreateLdaIcon.16x16" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/create-lda-icon.png"/>
-        <bt:Image id="CreateLdaIcon.32x32" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/create-lda-icon.png"/>
-        <bt:Image id="CreateLdaIcon.80x80" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/create-lda-icon.png"/>
-        <bt:Image id="DetailsIcon.16x16" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/details-icon.png"/>
-        <bt:Image id="DetailsIcon.32x32" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/details-icon.png"/>
-        <bt:Image id="DetailsIcon.80x80" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/details-icon.png"/>
-        <bt:Image id="SettingsIcon.16x16" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/settings-icon.png"/>
-        <bt:Image id="SettingsIcon.32x32" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/settings-icon.png"/>
-        <bt:Image id="SettingsIcon.80x80" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/settings-icon.png"/>
-        <bt:Image id="EmailIcon.16x16" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
-        <bt:Image id="EmailIcon.32x32" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
-        <bt:Image id="EmailIcon.80x80" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
-        <bt:Image id="CallIcon.16x16" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
-        <bt:Image id="CallIcon.32x32" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
-        <bt:Image id="CallIcon.80x80" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
+        <bt:Image id="Icon.16x16" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/icon-16.png"/>
+        <bt:Image id="Icon.32x32" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/icon-32.png"/>
+        <bt:Image id="Icon.80x80" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/icon-80.png"/>
+        <bt:Image id="CreateLdaIcon.16x16" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/create-lda-icon.png"/>
+        <bt:Image id="CreateLdaIcon.32x32" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/create-lda-icon.png"/>
+        <bt:Image id="CreateLdaIcon.80x80" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/create-lda-icon.png"/>
+        <bt:Image id="DetailsIcon.16x16" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/details-icon.png"/>
+        <bt:Image id="DetailsIcon.32x32" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/details-icon.png"/>
+        <bt:Image id="DetailsIcon.80x80" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/details-icon.png"/>
+        <bt:Image id="SettingsIcon.16x16" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/settings-icon.png"/>
+        <bt:Image id="SettingsIcon.32x32" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/settings-icon.png"/>
+        <bt:Image id="SettingsIcon.80x80" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/settings-icon.png"/>
+        <bt:Image id="EmailIcon.16x16" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
+        <bt:Image id="EmailIcon.32x32" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
+        <bt:Image id="EmailIcon.80x80" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/email-icon.png"/>
+        <bt:Image id="CallIcon.16x16" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
+        <bt:Image id="CallIcon.32x32" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
+        <bt:Image id="CallIcon.80x80" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/assets/call-icon.png"/>
       </bt:Images>
       <bt:Urls>
         <bt:Url id="GetStarted.LearnMoreUrl" DefaultValue="https://go.microsoft.com/fwlink/?LinkId=276812"/>
-        <bt:Url id="Commands.Url" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/commands/commands.html"/>
-        <bt:Url id="StudentView.Url" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/index.html?page=student-view"/>
-        <bt:Url id="Settings.Url" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/index.html?page=settings"/>
-        <bt:Url id="CreateLdaDialog.Url" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/index.html?page=create-lda"/>
-        <bt:Url id="WelcomeDialog.Url" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/welcome-dialog.html"/>
-        <bt:Url id="PersonalizedEmail.Url" DefaultValue="https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/index.html?page=personalized-email"/>
+        <bt:Url id="Commands.Url" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/commands/commands.html"/>
+        <bt:Url id="StudentView.Url" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/index.html?page=student-view"/>
+        <bt:Url id="Settings.Url" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/index.html?page=settings"/>
+        <bt:Url id="CreateLdaDialog.Url" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/index.html?page=create-lda"/>
+        <bt:Url id="WelcomeDialog.Url" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/welcome-dialog.html"/>
+        <bt:Url id="PersonalizedEmail.Url" DefaultValue="https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/index.html?page=personalized-email"/>
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Get started with the Retention Add-in!"/>
@@ -229,11 +229,11 @@
     -->
     <WebApplicationInfo>
       <Id>71f37f39-a330-413a-be61-0baa5ce03ea3</Id>
-      <Resource>api://northbridge-university.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3</Resource>
+      <Resource>api://Northbridge-University.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3</Resource>
       <Scopes>
         <Scope>openid</Scope>
         <Scope>profile</Scope>
-        <Scope>api://northbridge-university.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user</Scope>
+        <Scope>api://Northbridge-University.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3/access_as_user</Scope>
       </Scopes>
     </WebApplicationInfo>
   </VersionOverrides>

--- a/react/config/vite.config.js
+++ b/react/config/vite.config.js
@@ -5,7 +5,7 @@ import path from 'path';
 
 export default defineConfig({
   // FIX: Set the base path to correctly resolve assets when deployed to the 
-  // GitHub Pages subfolder (https://northbridge-university.github.io/Student-Retention-Add-in/react/dist/).
+  // GitHub Pages subfolder (https://Northbridge-University.github.io/Student-Retention-Add-in/react/dist/).
   // Updated to include 'dist/' because the production files are served from that subdirectory.
   base: '/Student-Retention-Add-in/react/dist/', 
   plugins: [react()],


### PR DESCRIPTION
## Summary
Updates all references to the GitHub organization from lowercase `northbridge-university` to proper casing `Northbridge-University` across configuration files, documentation, and code comments. This ensures consistency with the actual GitHub organization name and prevents potential URL resolution issues.

## Changes
- **manifest.xml**: Updated all 28 URL references (IconUrl, AppDomain, SourceLocation, image assets, command URLs, and WebApplicationInfo Resource/Scope URIs) to use `Northbridge-University` casing
- **README.md**: Corrected GitHub Pages production URL and Vercel staging URL references, plus documentation of preview URL patterns
- **documentation/MICROSOFT_SSO_SETUP.md**: Updated Azure AD redirect URI and Application ID URI examples to use correct casing
- **commands/src/master-list-import.js**: Fixed comment reference to production host
- **react/config/vite.config.js**: Updated comment documenting GitHub Pages deployment path

## Implementation Details
Most of these references (asset URLs, `AppDomain`, `SourceLocation`, docs, comments) are cosmetic — the GitHub Pages hostname is case-insensitive at the domain portion, so serving is unaffected.

**One reference is NOT cosmetic:** the `WebApplicationInfo` → `Resource` / `Scope` SSO Application ID URI (`api://Northbridge-University.github.io/71f37f39-...`). Office sends this string to Azure AD, which matches it **exactly** against the app registration's `identifierUris`. Changing its casing requires a matching change on the Azure side (see below) or Single Sign-On will fail.

## ⚠️ Required Azure AD app registration follow-up (not in this diff)
This PR changes the SSO Resource URI, but the Azure AD app registration (`Student Retention Kit`, appId `71f37f39-a330-413a-be61-0baa5ce03ea3`) was still pointing its `identifierUris` at the **old owner (`vsblanco`)** and never had a `Northbridge-University` entry. Until the app registration is updated, prod SSO will not resolve.

Azure manifest changes needed (Azure Portal → App registrations → Student Retention Kit → Manifest):
- **`identifierUris`**: add `api://Northbridge-University.github.io/71f37f39-a330-413a-be61-0baa5ce03ea3` (exact case, to match `manifest.xml`); keep `api://student-retention-kit.vercel.app/...` (staging); drop the stale `vsblanco.*` entries.
- **`spa.redirectUris`**: keep `https://northbridge-university.github.io/...` **lowercase** (browsers lowercase the redirect host); remove the stale `vsblanco.*` and `angelbaezmd.*` hosts; keep the SharePoint/Office host origins and `localhost:3000`.

Note: `identifierUris` matches are exact-case, but `redirectUris` hosts are effectively lowercase-only — the two URL types intentionally use different casing.

https://claude.ai/code/session_01VHRENbqd5LuL7fqtGmoZRi