### PR TITLE
Add diagnostics for Office document-settings save failures

### DIFF
--- a/react/src/components/createLDA/LDAManager.jsx
+++ b/react/src/components/createLDA/LDAManager.jsx
@@ -9,6 +9,7 @@ import React, { useState, useEffect } from 'react';
 import { Info, CheckCircle2, Circle, Loader2, ArrowLeft, AlertCircle, ChevronRight, Plus, Pencil, Trash2, X, ClipboardList } from 'lucide-react';
 import { createLDA, detectCampuses, detectProgramVersions, predictAdvisorDistribution, checkMissingLDAColumns, addColumnsToMasterList, checkMasterListExists } from './ldaProcessor';
 import { DEFAULT_RISK_INDEX_SETTINGS, sanitizeRiskIndexSettings } from './riskIndex';
+import { saveDocumentSetting } from '../utility/documentSettings';
 
 // --- CONFIGURATION: Steps matching the processor logic ---
 const PROCESS_STEPS = [
@@ -205,8 +206,8 @@ export default function CreateLDAManager({ onReady } = {}) {
       if (typeof window !== 'undefined' && window.Office && Office.context && Office.context.document && Office.context.document.settings) {
         const wb = Office.context.document.settings.get('workbookSettings') || {};
         wb[key] = value;
-        Office.context.document.settings.set('workbookSettings', wb);
-        Office.context.document.settings.saveAsync(() => {});
+        // Diagnostic saver logs the real error + size breakdown on failure.
+        saveDocumentSetting('workbookSettings', wb, `LDAManager.saveToWorkbookSettings(${key})`);
       }
     } catch (e) {
       console.error(`Failed to save ${key}:`, e);

--- a/react/src/components/createLDA/ldaProcessor.js
+++ b/react/src/components/createLDA/ldaProcessor.js
@@ -9,6 +9,7 @@
  */
 
 import { getWorkbookSettings } from '../utility/getSettings';
+import { saveDocumentSetting } from '../utility/documentSettings';
 import { defaultColumns } from '../settings/DefaultSettings';
 import { MASTER_LIST_SHEET, HISTORY_SHEET, BATCH_SIZE } from '../../../../shared/constants.js';
 import { STUDENT_ID_ALIASES, STUDENT_NUMBER_ALIASES, LAST_LDA_ALIASES } from '../../../../shared/columnAliases.js';
@@ -285,8 +286,7 @@ export async function createLDA(userOverrides, onProgress, onBatchProgress = nul
         if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
             const existing = Office.context.document.settings.get('workbookSettings');
             if (!existing || !Array.isArray(existing.columns) || existing.columns.length === 0) {
-                Office.context.document.settings.set('workbookSettings', workbookSettings);
-                Office.context.document.settings.saveAsync(() => {});
+                saveDocumentSetting('workbookSettings', workbookSettings, 'ldaProcessor.autoInitColumns');
             }
         }
 

--- a/react/src/components/createLDA/riskIndex.js
+++ b/react/src/components/createLDA/riskIndex.js
@@ -26,6 +26,7 @@ import {
     GENDER_ALIASES,
     PROFILE_PICTURE_ALIASES,
 } from '../../../../shared/columnAliases.js';
+import { saveDocumentSetting } from '../utility/documentSettings.js';
 
 export const LDA_HISTORY_KEY = 'LDAHistory';
 
@@ -475,14 +476,10 @@ export function loadLdaHistory() {
 }
 
 export function saveLdaHistory(history) {
-    try {
-        if (typeof Office !== 'undefined' && Office.context && Office.context.document && Office.context.document.settings) {
-            Office.context.document.settings.set(LDA_HISTORY_KEY, history);
-            Office.context.document.settings.saveAsync(() => {});
-        }
-    } catch (e) {
-        console.warn('riskIndex: failed to save LDAHistory setting', e);
-    }
+    // LDAHistory grows one entry per day and is the most likely key to push the
+    // document-settings blob over Excel's size cap. Route through the diagnostic
+    // saver so a failure here is logged with its size instead of being swallowed.
+    return saveDocumentSetting(LDA_HISTORY_KEY, history, 'riskIndex.saveLdaHistory');
 }
 
 /**

--- a/react/src/components/createLDA/riskIndex.js
+++ b/react/src/components/createLDA/riskIndex.js
@@ -483,6 +483,17 @@ export function saveLdaHistory(history) {
 }
 
 /**
+ * Wipe all saved LDA history, resetting the store to an empty (but valid)
+ * shape. Every student's Risk Index count derives from this history, so
+ * clearing it resets those counts to zero. Also the fastest way to shrink an
+ * oversized document-settings blob.
+ * @returns {Promise<boolean>} true on a confirmed successful save.
+ */
+export function clearLdaHistory() {
+    return saveDocumentSetting(LDA_HISTORY_KEY, { version: 1, days: {} }, 'riskIndex.clearLdaHistory');
+}
+
+/**
  * Current Risk Index config from workbook settings (sanitized, with defaults).
  * Stored as flat keys (riskIndexEnabled, riskIndexThreshold,
  * riskIndexShowColumn) to match the Settings page's schema-driven rows.

--- a/react/src/components/settings/DefaultSettings.jsx
+++ b/react/src/components/settings/DefaultSettings.jsx
@@ -167,6 +167,14 @@ export const defaultWorkbookSettings = [
 		description: 'Download the saved LDA history (date, student ID, LDA, days out) as a CSV file.'
 	},
 	{
+		id: 'clearLdaHistory',
+		label: 'Clear History',
+		type: 'action',
+		defaultValue: null,
+		section: 'Risk Index',
+		description: 'Permanently delete all saved LDA history. This resets every student\'s Risk Index to zero and cannot be undone — download a copy first if you want a backup.'
+	},
+	{
 		id: 'riskLeaderboard',
 		label: 'At-Risk Students',
 		type: 'riskleaderboard',

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -8,6 +8,7 @@ import PowerAutomateConfigModal from './PowerAutomateConfigModal'; // <-- ADDED:
 import TemplateImportExportModal from './TemplateImportExportModal'; // <-- ADDED: Template import/export modal
 import CustomParamImportExportModal from './CustomParamImportExportModal'; // <-- ADDED: Custom parameters import/export modal
 import AdvancedLDAModal from './AdvancedLDAModal'; // <-- ADDED: Create LDA advanced options modal
+import { saveDocumentSetting, measureDocumentSettings } from '../utility/documentSettings'; // <-- settings write diagnostics
 import LicenseChecker from '../utility/LicenseChecker'; // <-- License checker (requires Graph API)
 import UserInfoDisplay from '../utility/UserInfoDisplay'; // <-- User info from token (no API needed)
 import About from '../about/About'; // <-- ADDED: Import About component for Help tab
@@ -582,22 +583,16 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 	};
 
 	const saveWorkbookSettingsToDocument = (mapping) => {
-		try {
-			if (typeof window !== 'undefined' && window.Office && Office.context && Office.context.document && Office.context.document.settings) {
-				Office.context.document.settings.set(DOC_KEY, mapping);
-				Office.context.document.settings.saveAsync(result => {
-					if (result && result.status !== Office.AsyncResultStatus.Succeeded) {
-						console.warn('Failed to save workbook settings to document', result.error);
-					}
-				});
-			}
-		} catch (err) {
-			console.warn('Failed to save document settings', err);
-		}
+		// Routed through saveDocumentSetting so any OSF.DDA.Error surfaces the
+		// real code/message plus a per-key size breakdown (see documentSettings.js).
+		return saveDocumentSetting(DOC_KEY, mapping, 'Settings.saveWorkbookSettingsToDocument');
 	};
 
 	// one-time effect: ensure document has a workbook settings key; load it if present
 	useEffect(() => {
+		// Baseline size log on every Settings open, so an approaching size-cap
+		// problem is visible in the console before a save actually fails.
+		measureDocumentSettings('Settings mount');
 		const existing = loadWorkbookSettingsFromDocument();
 		if (existing && typeof existing === 'object') {
 			// if columns are missing or empty, inject defaultColumns (one-time import)

--- a/react/src/components/settings/Settings.jsx
+++ b/react/src/components/settings/Settings.jsx
@@ -14,7 +14,8 @@ import UserInfoDisplay from '../utility/UserInfoDisplay'; // <-- User info from 
 import About from '../about/About'; // <-- ADDED: Import About component for Help tab
 import { HISTORY_SHEET, MASTER_LIST_SHEET } from '../../../../shared/constants.js';
 import { getWorkbookUsers } from '../../services/workbookUsers.js';
-import { loadLdaHistory, historyToCsv } from '../createLDA/riskIndex.js';
+import { loadLdaHistory, historyToCsv, clearLdaHistory as clearLdaHistoryStore } from '../createLDA/riskIndex.js';
+import DeleteConfirmModal from './DeleteConfirmModal';
 import RiskIndexImportModal from './RiskIndexImportModal'; // <-- ADDED: Risk Index history import modal
 import RiskIndexLeaderboard from './RiskIndexLeaderboard'; // <-- ADDED: ranked at-risk students card
 
@@ -238,6 +239,10 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 	// Risk Index: LDA history import modal + download state
 	const [riskImportModalOpen, setRiskImportModalOpen] = useState(false);
 	const [downloadingLdaHistory, setDownloadingLdaHistory] = useState(false);
+	const [clearHistoryModalOpen, setClearHistoryModalOpen] = useState(false);
+	const [clearingLdaHistory, setClearingLdaHistory] = useState(false);
+	// Bumped to force the At-Risk leaderboard to reload after a history clear.
+	const [leaderboardRefresh, setLeaderboardRefresh] = useState(0);
 
 	// Default headers for a freshly-created Student History sheet. Each name is
 	// a canonical alias from shared/columnAliases.js so the existing add/edit/
@@ -480,6 +485,28 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 		}
 	};
 
+	// Risk Index: wipe the saved LDA history (confirmed via modal). Resets every
+	// student's Risk Index count to zero; also shrinks the document-settings blob.
+	const handleClearLdaHistory = async () => {
+		if (clearingLdaHistory) return;
+		setClearingLdaHistory(true);
+		try {
+			const ok = await clearLdaHistoryStore();
+			if (!ok) {
+				alert('Failed to clear LDA history. See the browser console for details.');
+				return;
+			}
+			setClearHistoryModalOpen(false);
+			// Reflect the reset in the At-Risk leaderboard without a manual refresh.
+			setLeaderboardRefresh(n => n + 1);
+		} catch (err) {
+			console.error('Failed to clear LDA history:', err);
+			alert(err.message || 'Failed to clear LDA history');
+		} finally {
+			setClearingLdaHistory(false);
+		}
+	};
+
 	const openArrayModal = async (setting, currentValue, updater) => {
 		// if this is the columns setting, read master list headers first
 		if (setting.id === 'columns') {
@@ -666,10 +693,10 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 			if (setting.type === 'userslist') {
 				return <UsersList key={setting.id} />;
 			}
-			// Custom full-width row: students ranked by Risk Index. Keyed off the
-			// import modal's open state so closing it reloads fresh history.
+			// Custom full-width row: students ranked by Risk Index. Reloads when the
+			// import modal closes or the history is cleared (either changes the token).
 			if (setting.type === 'riskleaderboard') {
-				return <RiskIndexLeaderboard key={setting.id} refreshToken={riskImportModalOpen} />;
+				return <RiskIndexLeaderboard key={setting.id} refreshToken={`${riskImportModalOpen}|${leaderboardRefresh}`} />;
 			}
 			return (
 				<div key={setting.id} style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center', gap: 8, width: '100%', boxSizing: 'border-box' }}>
@@ -860,6 +887,12 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 										<line x1="12" y1="3" x2="12" y2="15" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
 									</svg>
 								);
+								const trashIcon = (
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+										<polyline points="3 6 5 6 21 6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+										<path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+									</svg>
+								);
 
 								// historyCommentCount is null both before the workbook summary loads and
 								// when the History sheet doesn't exist — either way, there's nothing to
@@ -900,6 +933,13 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 										icon: downloadIcon,
 										idle: 'Download',
 										busyLabel: 'Downloading...',
+									},
+									clearLdaHistory: {
+										run: () => setClearHistoryModalOpen(true),
+										busy: clearingLdaHistory,
+										icon: trashIcon,
+										idle: 'Clear',
+										busyLabel: 'Clearing...',
 									},
 								};
 								const action = actions[setting.id];
@@ -1252,6 +1292,15 @@ const Settings = ({ user, accessToken, onReady }) => { // <-- ADDED accessToken 
 			<RiskIndexImportModal
 				isOpen={riskImportModalOpen}
 				onClose={() => setRiskImportModalOpen(false)}
+			/>
+
+			<DeleteConfirmModal
+				isOpen={clearHistoryModalOpen}
+				title="Clear LDA history?"
+				message="This permanently deletes all saved LDA history and resets every student's Risk Index to zero. This cannot be undone. Consider using Download History first if you want a backup."
+				confirmLabel={clearingLdaHistory ? 'Clearing...' : 'Clear History'}
+				onConfirm={handleClearLdaHistory}
+				onCancel={() => { if (!clearingLdaHistory) setClearHistoryModalOpen(false); }}
 			/>
 		</div>
 	);

--- a/react/src/components/utility/documentSettings.js
+++ b/react/src/components/utility/documentSettings.js
@@ -1,0 +1,201 @@
+// Centralized diagnostics + safe writes for Office document settings.
+//
+// Every persistent add-in setting is stored in the SAME document-settings
+// blob (`Office.context.document.settings`). `saveAsync` serializes and
+// writes that ENTIRE blob at once, so if any single key grows past Excel's
+// size cap, EVERY save fails with a generic `OSF.DDA.Error` — including
+// unrelated writes like the Settings columns. These helpers make that
+// failure legible: they surface the real error code/name/message and log a
+// per-key size breakdown so we can see which key blew the budget.
+//
+// All logs are prefixed with `[SRK settings]` so they're easy to filter in
+// the browser console.
+
+const LOG_PREFIX = '[SRK settings]';
+
+// Top-level keys this add-in stores under Office.context.document.settings.
+// Keep in sync with the writers:
+//   'workbookSettings' — columns, Create-LDA toggles, emergencyContacts,
+//                        registered users, lastKnownHeaders (Settings.jsx,
+//                        LDAManager.jsx, emergencyContacts.js, workbookUsers.js)
+//   'LDAHistory'       — Risk Index daily snapshots (riskIndex.js, LDA_HISTORY_KEY)
+// (SSO/email data lives in the separate context.workbook.settings store and
+// does NOT count toward this blob.)
+export const KNOWN_DOC_SETTING_KEYS = ['workbookSettings', 'LDAHistory'];
+
+/** True when the Office document-settings API is usable in this runtime. */
+export function isDocumentSettingsAvailable() {
+	return (
+		typeof window !== 'undefined' &&
+		window.Office &&
+		Office.context &&
+		Office.context.document &&
+		Office.context.document.settings
+	);
+}
+
+/**
+ * Pull the useful fields out of an OSF.DDA.Error (or any thrown value).
+ * Office error objects stringify to a bare "OSF.DDA.Error", hiding the code
+ * and message — this flattens them into something loggable.
+ * @returns {{ name: string, code: (number|string|null), message: string }}
+ */
+export function describeOfficeError(error) {
+	if (!error) return { name: 'Unknown', code: null, message: 'No error object provided' };
+	// Office AsyncResult.error exposes name/code/message; plain Errors have name/message.
+	const name = error.name ?? error.constructor?.name ?? 'Error';
+	const code = (error.code !== undefined && error.code !== null) ? error.code : null;
+	const message = error.message ?? String(error);
+	return { name, code, message };
+}
+
+/** UTF-8 byte length of a JSON-serialized value; -1 if it can't be serialized. */
+export function byteSize(value) {
+	let json;
+	try {
+		json = JSON.stringify(value);
+	} catch {
+		return -1;
+	}
+	if (json === undefined) return 0;
+	try {
+		if (typeof TextEncoder !== 'undefined') {
+			return new TextEncoder().encode(json).length;
+		}
+	} catch {
+		/* fall through to length estimate */
+	}
+	return json.length;
+}
+
+function formatBytes(n) {
+	if (n < 0) return 'unserializable';
+	if (n < 1024) return `${n} B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+	return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+/**
+ * Measure the size of each known settings key plus the combined total, and
+ * log a breakdown. This is the key diagnostic for `OSF.DDA.Error` on save:
+ * whichever key dominates the total is the one pushing the blob over Excel's
+ * cap and breaking every write.
+ * @param {string} contextLabel - where the measurement was taken from.
+ * @returns {{ perKey: Object<string, number>, total: number } | null}
+ */
+export function measureDocumentSettings(contextLabel = '') {
+	if (!isDocumentSettingsAvailable()) return null;
+	const perKey = {};
+	let total = 0;
+	for (const key of KNOWN_DOC_SETTING_KEYS) {
+		let size = 0;
+		try {
+			const val = Office.context.document.settings.get(key);
+			size = val === undefined || val === null ? 0 : byteSize(val);
+		} catch (e) {
+			size = -1;
+			console.warn(`${LOG_PREFIX} could not read key "${key}" while measuring`, e);
+		}
+		perKey[key] = size;
+		if (size > 0) total += size;
+	}
+	const summary = KNOWN_DOC_SETTING_KEYS
+		.map(k => `${k}=${formatBytes(perKey[k])}`)
+		.join(', ');
+	console.info(
+		`${LOG_PREFIX} size breakdown${contextLabel ? ` (${contextLabel})` : ''}: ` +
+		`total=${formatBytes(total)} | ${summary}`
+	);
+	return { perKey, total };
+}
+
+/**
+ * Log the outcome of a settings `saveAsync`. On failure it dumps the full
+ * error detail AND a size breakdown so the point of failure is unambiguous.
+ * @param {string} label - identifies the call site (e.g. 'Settings.columns').
+ * @param {object} result - the Office AsyncResult passed to the callback.
+ * @returns {boolean} whether the save succeeded.
+ */
+export function logSettingsSaveResult(label, result) {
+	const succeeded =
+		result &&
+		typeof Office !== 'undefined' &&
+		Office.AsyncResultStatus &&
+		result.status === Office.AsyncResultStatus.Succeeded;
+
+	if (succeeded) {
+		console.debug(`${LOG_PREFIX} save OK: ${label}`);
+		return true;
+	}
+
+	const err = describeOfficeError(result && result.error);
+	console.error(
+		`${LOG_PREFIX} save FAILED: ${label} — ` +
+		`name=${err.name} code=${err.code ?? 'n/a'} message="${err.message}"`,
+		result && result.error
+	);
+	// Show which key is oversized — the usual reason a save is rejected.
+	measureDocumentSettings(`after failed save: ${label}`);
+	return false;
+}
+
+/**
+ * Set one key and persist the whole settings blob, with full diagnostics on
+ * both the synchronous `set` (can throw on non-serializable values) and the
+ * async `saveAsync` (fails when the combined blob is too large).
+ *
+ * Fire-and-forget friendly, but returns a Promise<boolean> for callers that
+ * want to await the outcome.
+ *
+ * @param {string} key   - document settings key to write.
+ * @param {*}      value - JSON-serializable value to store.
+ * @param {string} label - call-site label for logs.
+ * @returns {Promise<boolean>} true on a confirmed successful save.
+ */
+export function saveDocumentSetting(key, value, label) {
+	if (!isDocumentSettingsAvailable()) {
+		console.warn(`${LOG_PREFIX} skip save (${label}): Office document settings unavailable`);
+		return Promise.resolve(false);
+	}
+
+	// Warn early if the value we're about to store is itself huge — that's the
+	// key most likely to be pushing the whole blob over the limit.
+	const thisSize = byteSize(value);
+	if (thisSize < 0) {
+		console.error(`${LOG_PREFIX} value for "${key}" (${label}) is not JSON-serializable; save aborted`);
+		return Promise.resolve(false);
+	}
+	if (thisSize > 512 * 1024) {
+		console.warn(`${LOG_PREFIX} large value for "${key}" (${label}): ${formatBytes(thisSize)}`);
+	}
+
+	return new Promise(resolve => {
+		try {
+			Office.context.document.settings.set(key, value);
+		} catch (err) {
+			const info = describeOfficeError(err);
+			console.error(
+				`${LOG_PREFIX} set() threw for "${key}" (${label}) — ` +
+				`name=${info.name} message="${info.message}"`,
+				err
+			);
+			resolve(false);
+			return;
+		}
+
+		try {
+			Office.context.document.settings.saveAsync(result => {
+				resolve(logSettingsSaveResult(`${label} [key=${key}]`, result));
+			});
+		} catch (err) {
+			const info = describeOfficeError(err);
+			console.error(
+				`${LOG_PREFIX} saveAsync() threw for "${key}" (${label}) — ` +
+				`name=${info.name} message="${info.message}"`,
+				err
+			);
+			measureDocumentSettings(`after saveAsync throw: ${label}`);
+			resolve(false);
+		}
+	});
+}

--- a/react/src/services/emergencyContacts.js
+++ b/react/src/services/emergencyContacts.js
@@ -17,6 +17,8 @@
  * that student is viewed, on any machine that opens the workbook.
  */
 
+import { saveDocumentSetting } from '../components/utility/documentSettings.js';
+
 const DOC_KEY = 'workbookSettings';
 const CONTACTS_KEY = 'emergencyContacts';
 
@@ -40,21 +42,9 @@ function readWorkbookSettings() {
 
 function writeWorkbookSettings(mapping) {
     if (!isOfficeReady()) return Promise.resolve(false);
-    return new Promise(resolve => {
-        try {
-            Office.context.document.settings.set(DOC_KEY, mapping);
-            Office.context.document.settings.saveAsync(result => {
-                const ok = result && result.status === Office.AsyncResultStatus.Succeeded;
-                if (!ok && result && result.error) {
-                    console.warn('emergencyContacts: saveAsync failed', result.error);
-                }
-                resolve(!!ok);
-            });
-        } catch (err) {
-            console.warn('emergencyContacts: failed to set document settings', err);
-            resolve(false);
-        }
-    });
+    // Diagnostic saver: on failure logs the real error code/message and a
+    // per-key size breakdown (see documentSettings.js).
+    return saveDocumentSetting(DOC_KEY, mapping, 'emergencyContacts.writeWorkbookSettings');
 }
 
 // Normalize an identifier to a non-empty string key, or null when unusable.

--- a/react/src/services/workbookUsers.js
+++ b/react/src/services/workbookUsers.js
@@ -16,6 +16,8 @@
  * be used for future automation (e.g. routing, distribution lists).
  */
 
+import { saveDocumentSetting } from '../components/utility/documentSettings.js';
+
 const DOC_KEY = 'workbookSettings';
 const USERS_KEY = 'users';
 
@@ -39,21 +41,9 @@ function readWorkbookSettings() {
 
 function writeWorkbookSettings(mapping) {
     if (!isOfficeReady()) return Promise.resolve(false);
-    return new Promise(resolve => {
-        try {
-            Office.context.document.settings.set(DOC_KEY, mapping);
-            Office.context.document.settings.saveAsync(result => {
-                const ok = result && result.status === Office.AsyncResultStatus.Succeeded;
-                if (!ok && result && result.error) {
-                    console.warn('workbookUsers: saveAsync failed', result.error);
-                }
-                resolve(!!ok);
-            });
-        } catch (err) {
-            console.warn('workbookUsers: failed to set document settings', err);
-            resolve(false);
-        }
-    });
+    // Diagnostic saver: on failure logs the real error code/message and a
+    // per-key size breakdown (see documentSettings.js).
+    return saveDocumentSetting(DOC_KEY, mapping, 'workbookUsers.writeWorkbookSettings');
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds centralized diagnostics and safe-write helpers for Office document settings to surface real error codes/messages and per-key size breakdowns when saves fail. Office's `saveAsync` serializes the entire settings blob at once, so when any single key exceeds Excel's size cap, all saves fail with a generic `OSF.DDA.Error` that hides the actual problem. These new utilities make that failure legible.

## Key Changes

- **New `documentSettings.js` utility module** with:
  - `saveDocumentSetting()` — wraps `set()` + `saveAsync()` with full error diagnostics
  - `measureDocumentSettings()` — logs per-key size breakdown (identifies which key is oversized)
  - `describeOfficeError()` — flattens Office error objects to expose code/message
  - `byteSize()` — calculates UTF-8 byte length of JSON-serialized values
  - All logs prefixed with `[SRK settings]` for easy console filtering

- **Settings.jsx** — refactored to use `saveDocumentSetting()` and call `measureDocumentSettings()` on mount for baseline diagnostics

- **Risk Index history management**:
  - New `clearLdaHistory()` export in `riskIndex.js` to wipe saved history and reset all student Risk Index counts to zero
  - New "Clear History" action button in Settings UI with confirmation modal
  - Leaderboard refresh token bumped when history is cleared so the At-Risk students card reloads without manual refresh

- **Consolidated document-settings writes** across:
  - `emergencyContacts.js` — now routes through `saveDocumentSetting()`
  - `workbookUsers.js` — now routes through `saveDocumentSetting()`
  - `ldaProcessor.js` — now routes through `saveDocumentSetting()`
  - `LDAManager.jsx` — now routes through `saveDocumentSetting()`

## Implementation Details

- `LDAHistory` is the most likely key to push the blob over Excel's size cap (grows one entry per day), so it now logs size warnings and full diagnostics on failure
- The "Clear History" feature is the fastest way to shrink an oversized blob without losing other settings
- All saves are fire-and-forget friendly but return `Promise<boolean>` for callers that need to await the outcome
- Baseline size measurement on Settings mount helps catch approaching size-cap problems before a save actually fails

https://claude.ai/code/session_01KM7nRuMMQPDudp9SZGMMke