### PR TITLE
Normalize preserved attendance when import omits the Attendance column

### DIFF
--- a/commands/src/master-list-import.js
+++ b/commands/src/master-list-import.js
@@ -659,7 +659,14 @@ export async function importMasterListFromExtension(payload) {
                                 formulaRow[colIdx] = preserved.formulas[colIdx];
                                 newRow[colIdx] = preserved.values[colIdx] || "";
                             } else if (preserved.values[colIdx] !== undefined) {
-                                newRow[colIdx] = preserved.values[colIdx];
+                                let preservedVal = preserved.values[colIdx];
+                                // Attendance carried over from the existing sheet must be
+                                // normalized too, otherwise a stale whole-number value (43)
+                                // re-renders as "4300%" under the "0%" number format.
+                                if (colIdx === masterAttendanceCol && preservedVal !== "") {
+                                    preservedVal = normalizeAttendanceValue(preservedVal);
+                                }
+                                newRow[colIdx] = preservedVal;
                             }
                         }
                     }


### PR DESCRIPTION
Follow-up to the attendance `6700%` fix (#350/#351), covering the second code path.

## Problem
When an incoming master list has **no** Attendance % column, the existing attendance is carried over via the unmatched-column preservation path, which wrote the stored value back verbatim. A stale whole-number value (`43`) then re-rendered as `4300%` under the column's `0%` number format.

## Fix
Apply the same `normalizeAttendanceValue` logic (used on the incoming-data path) to preserved attendance, so it's written back as a fraction (`43` → `0.43`) and displays as `43%`. The helper is idempotent, so already-correct fractional values (`0.43`) are left unchanged — this fixes stale data on re-import without harming correct data.

## Notes
- Change is entirely in the `commands/` runtime (raw ES modules) — **no `react/dist` rebuild required**.
- Commands test suite passes (245/245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiRg66C7UovBWHefPpKC8s)_